### PR TITLE
Add Announcement mixin across all contrib modules

### DIFF
--- a/src/opinionated_mixins/contrib/dataclasses/announcement.py
+++ b/src/opinionated_mixins/contrib/dataclasses/announcement.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import dataclasses
+
+from typing_extensions import Annotated, Doc
+
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+@dataclasses.dataclass
+class Announcement:
+    """Announcement mixin for stdlib dataclasses."""
+
+    title: Annotated[str, Doc("Title of the announcement")]
+    content: Annotated[str, Doc("Content of the announcement")]
+    category: Annotated[AnnouncementCategory, Doc("Category of the announcement")] = dataclasses.field(
+        default=AnnouncementCategory.GENERAL
+    )

--- a/src/opinionated_mixins/contrib/mongoengine/__init__.py
+++ b/src/opinionated_mixins/contrib/mongoengine/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from .announcement import Announcement as Announcement

--- a/src/opinionated_mixins/contrib/mongoengine/announcement.py
+++ b/src/opinionated_mixins/contrib/mongoengine/announcement.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from typing import Any, ClassVar, Dict
+
+from mongoengine import StringField
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class Announcement:
+    """Announcement mixin for MongoEngine documents."""
+
+    meta: ClassVar[Dict[str, Any]] = {"allow_inheritance": True}
+
+    title = StringField(required=True, max_length=255)
+    content = StringField(required=True)
+    category = StringField(
+        required=True,
+        default=AnnouncementCategory.GENERAL.value,
+        choices=[c.value for c in AnnouncementCategory],
+    )

--- a/src/opinionated_mixins/contrib/odmantic/__init__.py
+++ b/src/opinionated_mixins/contrib/odmantic/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from .announcement import Announcement as Announcement

--- a/src/opinionated_mixins/contrib/odmantic/announcement.py
+++ b/src/opinionated_mixins/contrib/odmantic/announcement.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from odmantic import Field
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class Announcement:
+    """Announcement mixin for ODMantic models."""
+
+    title: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(..., min_length=1)
+    category: AnnouncementCategory = Field(default=AnnouncementCategory.GENERAL)

--- a/src/opinionated_mixins/contrib/pydantic/__init__.py
+++ b/src/opinionated_mixins/contrib/pydantic/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from .announcement import Announcement as Announcement

--- a/src/opinionated_mixins/contrib/pydantic/announcement.py
+++ b/src/opinionated_mixins/contrib/pydantic/announcement.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import AnnouncementCategory
+from pydantic import BaseModel, Field
+
+
+class Announcement(BaseModel):
+    """Announcement mixin for Pydantic models."""
+
+    title: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(..., min_length=1)
+    category: AnnouncementCategory = Field(default=AnnouncementCategory.GENERAL)

--- a/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from .announcement import Announcement as Announcement

--- a/src/opinionated_mixins/contrib/sqlalchemy/announcement.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/announcement.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import AnnouncementCategory
+from sqlalchemy import Column, Enum, String, Text
+from sqlalchemy.orm import declarative_mixin
+
+
+@declarative_mixin
+class Announcement:
+    """Announcement mixin for SQLAlchemy models."""
+
+    __abstract__ = True
+
+    title = Column(String(255), nullable=False, index=True)
+    content = Column(Text, nullable=False)
+    category = Column(Enum(AnnouncementCategory), nullable=False, default=AnnouncementCategory.GENERAL)

--- a/src/opinionated_mixins/contrib/sqlmodel/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from .announcement import Announcement as Announcement

--- a/src/opinionated_mixins/contrib/sqlmodel/announcement.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/announcement.py
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement
+from opinionated_mixins.contrib.sqlalchemy.announcement import (
+    Announcement as Announcement,
+)

--- a/src/opinionated_mixins/contrib/wtforms/__init__.py
+++ b/src/opinionated_mixins/contrib/wtforms/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from .announcement import Announcement as Announcement

--- a/src/opinionated_mixins/contrib/wtforms/announcement.py
+++ b/src/opinionated_mixins/contrib/wtforms/announcement.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import AnnouncementCategory
+from wtforms import SelectField, StringField, TextAreaField
+from wtforms.validators import DataRequired, Length
+
+
+class Announcement:
+    """Announcement mixin for WTForms forms."""
+
+    title = StringField(
+        label="Title",
+        validators=[Length(min=1, max=255), DataRequired()],
+    )
+    content = TextAreaField(
+        label="Content",
+        validators=[DataRequired()],
+    )
+    category = SelectField(
+        label="Category",
+        choices=[(c.value, c.value.title()) for c in AnnouncementCategory],
+        default=AnnouncementCategory.GENERAL.value,
+        validators=[DataRequired()],
+    )

--- a/src/opinionated_mixins/enums.py
+++ b/src/opinionated_mixins/enums.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import enum
+
+
+class AnnouncementCategory(str, enum.Enum):
+    """Category of an announcement."""
+
+    GENERAL = "general"
+    INFO = "info"
+    WARNING = "warning"
+    SUCCESS = "success"
+    ERROR = "error"
+    MAINTENANCE = "maintenance"
+    UPDATE = "update"
+    EVENT = "event"

--- a/tests/dataclasses/__init__.py
+++ b/tests/dataclasses/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement

--- a/tests/dataclasses/test_announcement.py
+++ b/tests/dataclasses/test_announcement.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import dataclasses
+
+from opinionated_mixins.contrib.dataclasses import Announcement
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class TestDataclassesAnnouncement:
+    def test_is_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(Announcement)
+
+    def test_create_with_defaults(self) -> None:
+        obj = Announcement(title="Test", content="Hello world")
+        assert obj.title == "Test"
+        assert obj.content == "Hello world"
+        assert obj.category == AnnouncementCategory.GENERAL
+
+    def test_create_with_category(self) -> None:
+        obj = Announcement(
+            title="Event",
+            content="Join us",
+            category=AnnouncementCategory.EVENT,
+        )
+        assert obj.category == AnnouncementCategory.EVENT
+
+    def test_fields(self) -> None:
+        fields = {f.name for f in dataclasses.fields(Announcement)}
+        assert fields == {"title", "content", "category"}

--- a/tests/mongoengine/__init__.py
+++ b/tests/mongoengine/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement

--- a/tests/mongoengine/test_announcement.py
+++ b/tests/mongoengine/test_announcement.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.mongoengine import Announcement
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class TestMongoEngineAnnouncement:
+    def test_has_title_field(self) -> None:
+        assert hasattr(Announcement, "title")
+        assert Announcement.title.required is True
+        assert Announcement.title.max_length == 255
+
+    def test_has_content_field(self) -> None:
+        assert hasattr(Announcement, "content")
+        assert Announcement.content.required is True
+
+    def test_has_category_field(self) -> None:
+        assert hasattr(Announcement, "category")
+        assert Announcement.category.required is True
+        assert Announcement.category.default == AnnouncementCategory.GENERAL.value
+
+    def test_category_choices(self) -> None:
+        choices = Announcement.category.choices
+        expected = [c.value for c in AnnouncementCategory]
+        assert choices == expected

--- a/tests/odmantic/__init__.py
+++ b/tests/odmantic/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement

--- a/tests/odmantic/test_announcement.py
+++ b/tests/odmantic/test_announcement.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.odmantic import Announcement
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class TestODManticAnnouncement:
+    def test_has_expected_annotations(self) -> None:
+        annotations = Announcement.__annotations__
+        assert "title" in annotations
+        assert "content" in annotations
+        assert "category" in annotations
+
+    def test_category_default(self) -> None:
+        assert Announcement.category.pydantic_field_info.default == AnnouncementCategory.GENERAL

--- a/tests/pydantic/__init__.py
+++ b/tests/pydantic/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement

--- a/tests/pydantic/test_announcement.py
+++ b/tests/pydantic/test_announcement.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import pytest
+from pydantic import ValidationError
+
+from opinionated_mixins.contrib.pydantic import Announcement
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class TestPydanticAnnouncement:
+    def test_create_with_defaults(self) -> None:
+        obj = Announcement(title="Test", content="Hello world")
+        assert obj.title == "Test"
+        assert obj.content == "Hello world"
+        assert obj.category == AnnouncementCategory.GENERAL
+
+    def test_create_with_category(self) -> None:
+        obj = Announcement(
+            title="Update",
+            content="New feature",
+            category=AnnouncementCategory.UPDATE,
+        )
+        assert obj.category == AnnouncementCategory.UPDATE
+
+    def test_title_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Announcement(content="No title")  # type: ignore[call-arg]
+
+    def test_content_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Announcement(title="No content")  # type: ignore[call-arg]
+
+    def test_empty_title_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Announcement(title="", content="Body")
+
+    def test_title_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            Announcement(title="x" * 256, content="Body")
+
+    def test_category_from_string(self) -> None:
+        obj = Announcement(title="Test", content="Body", category="warning")  # type: ignore[arg-type]
+        assert obj.category == AnnouncementCategory.WARNING
+
+    def test_invalid_category_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Announcement(title="Test", content="Body", category="invalid")  # type: ignore[arg-type]

--- a/tests/sqlalchemy/__init__.py
+++ b/tests/sqlalchemy/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement

--- a/tests/sqlalchemy/test_announcement.py
+++ b/tests/sqlalchemy/test_announcement.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+from opinionated_mixins.contrib.sqlalchemy import Announcement
+from opinionated_mixins.enums import AnnouncementCategory
+
+Base = declarative_base()
+
+
+class MyAnnouncement(Announcement, Base):  # type: ignore[misc]
+    __tablename__ = "announcements"
+    id = Column(Integer, primary_key=True)
+
+
+class TestSQLAlchemyAnnouncement:
+    def setup_method(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+
+    def test_create_with_defaults(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyAnnouncement(title="Test", content="Hello world")
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.title == "Test"
+            assert obj.content == "Hello world"
+            assert obj.category == AnnouncementCategory.GENERAL
+
+    def test_create_with_category(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyAnnouncement(
+                title="Downtime",
+                content="Scheduled maintenance",
+                category=AnnouncementCategory.MAINTENANCE,
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.category == AnnouncementCategory.MAINTENANCE
+
+    def test_title_indexed(self) -> None:
+        table = MyAnnouncement.__table__
+        indexed_columns = {col.name for idx in table.indexes for col in idx.columns}
+        assert "title" in indexed_columns
+
+    def test_fields_exist(self) -> None:
+        columns = {c.name for c in MyAnnouncement.__table__.columns}
+        assert {"title", "content", "category"}.issubset(columns)

--- a/tests/sqlmodel/__init__.py
+++ b/tests/sqlmodel/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement

--- a/tests/sqlmodel/test_announcement.py
+++ b/tests/sqlmodel/test_announcement.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.sqlmodel import Announcement
+
+
+class TestSQLModelAnnouncement:
+    def test_reexports_sqlalchemy(self) -> None:
+        from opinionated_mixins.contrib.sqlalchemy import (
+            Announcement as SAAnnouncment,
+        )
+
+        assert Announcement is SAAnnouncment

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class TestAnnouncementCategory:
+    def test_values(self) -> None:
+        expected = [
+            "general",
+            "info",
+            "warning",
+            "success",
+            "error",
+            "maintenance",
+            "update",
+            "event",
+        ]
+        assert [c.value for c in AnnouncementCategory] == expected
+
+    def test_str_mixin(self) -> None:
+        assert AnnouncementCategory.GENERAL == "general"
+        assert isinstance(AnnouncementCategory.INFO, str)
+
+    def test_lookup_by_value(self) -> None:
+        assert AnnouncementCategory("warning") is AnnouncementCategory.WARNING

--- a/tests/wtforms/__init__.py
+++ b/tests/wtforms/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement

--- a/tests/wtforms/test_announcement.py
+++ b/tests/wtforms/test_announcement.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from wtforms import Form
+
+from opinionated_mixins.contrib.wtforms import Announcement
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class AnnouncementForm(Announcement, Form):  # type: ignore[misc]
+    pass
+
+
+class TestWTFormsAnnouncement:
+    def test_has_fields(self) -> None:
+        form = AnnouncementForm()
+        assert "title" in form._fields
+        assert "content" in form._fields
+        assert "category" in form._fields
+
+    def test_category_choices(self) -> None:
+        form = AnnouncementForm()
+        choice_values = [c[0] for c in form.category.choices]
+        expected = [c.value for c in AnnouncementCategory]
+        assert choice_values == expected
+
+    def test_category_default(self) -> None:
+        form = AnnouncementForm()
+        assert form.category.default == AnnouncementCategory.GENERAL.value
+
+    def test_valid_submission(self) -> None:
+        form = AnnouncementForm(
+            data={
+                "title": "Test",
+                "content": "Hello world",
+                "category": "general",
+            }
+        )
+        assert form.validate()


### PR DESCRIPTION
## Summary

- Add `AnnouncementCategory` enum with 8 values (`general`, `info`, `warning`, `success`, `error`, `maintenance`, `update`, `event`) in `src/opinionated_mixins/enums.py`
- Implement `Announcement` mixin with `title`, `content`, and `category` fields across all 7 contrib modules (sqlalchemy, pydantic, sqlmodel, mongoengine, odmantic, wtforms, dataclasses)
- Add 30 tests covering all modules

Closes #5

## Fields

| Field | Type | Required | Default |
|-------|------|----------|---------|
| `title` | `str` (max 255) | Yes | — |
| `content` | `str` (text) | Yes | — |
| `category` | `AnnouncementCategory` | Yes | `GENERAL` |

## Test plan

- [x] All 30 tests pass (`hatch run test`)
- [x] Lint passes (`hatch fmt --check`)
- [ ] Review field naming consistency across frameworks
- [ ] Verify SQLAlchemy mixin works with real DB session (in-memory SQLite tested)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements an `Announcement` mixin pattern across 7 different Python frameworks (SQLAlchemy, Pydantic, SQLModel, MongoEngine, ODMantic, WTForms, and dataclasses). It introduces a shared `AnnouncementCategory` enum with 8 category values (general, info, warning, success, error, maintenance, update, event) and provides framework-specific implementations of an `Announcement` mixin containing three fields: `title` (string, max 255 chars), `content` (text), and `category` (enum, defaults to GENERAL). Each implementation is tailored to its framework's conventions (e.g., SQLAlchemy uses Column definitions with an indexed title field, Pydantic uses Field validators, WTForms provides form fields with validators). The PR includes comprehensive test coverage with 30 tests validating field presence, default values, validation rules, and framework-specific behavior across all modules.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/opinionated_mixins/enums.py` |
| 2 | `tests/test_enums.py` |
| 3 | `src/opinionated_mixins/contrib/dataclasses/announcement.py` |
| 4 | `src/opinionated_mixins/contrib/dataclasses/__init__.py` |
| 5 | `tests/dataclasses/__init__.py` |
| 6 | `tests/dataclasses/test_announcement.py` |
| 7 | `src/opinionated_mixins/contrib/pydantic/announcement.py` |
| 8 | `src/opinionated_mixins/contrib/pydantic/__init__.py` |
| 9 | `tests/pydantic/__init__.py` |
| 10 | `tests/pydantic/test_announcement.py` |
| 11 | `src/opinionated_mixins/contrib/sqlalchemy/announcement.py` |
| 12 | `src/opinionated_mixins/contrib/sqlalchemy/__init__.py` |
| 13 | `tests/sqlalchemy/__init__.py` |
| 14 | `tests/sqlalchemy/test_announcement.py` |
| 15 | `src/opinionated_mixins/contrib/sqlmodel/announcement.py` |
| 16 | `src/opinionated_mixins/contrib/sqlmodel/__init__.py` |
| 17 | `tests/sqlmodel/__init__.py` |
| 18 | `tests/sqlmodel/test_announcement.py` |
| 19 | `src/opinionated_mixins/contrib/mongoengine/announcement.py` |
| 20 | `src/opinionated_mixins/contrib/mongoengine/__init__.py` |
| 21 | `tests/mongoengine/__init__.py` |
| 22 | `tests/mongoengine/test_announcement.py` |
| 23 | `src/opinionated_mixins/contrib/odmantic/announcement.py` |
| 24 | `src/opinionated_mixins/contrib/odmantic/__init__.py` |
| 25 | `tests/odmantic/__init__.py` |
| 26 | `tests/odmantic/test_announcement.py` |
| 27 | `src/opinionated_mixins/contrib/wtforms/announcement.py` |
| 28 | `src/opinionated_mixins/contrib/wtforms/__init__.py` |
| 29 | `tests/wtforms/__init__.py` |
| 30 | `tests/wtforms/test_announcement.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->