### PR TITLE
docs: improve project documentation and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/field_proposal.md
+++ b/.github/ISSUE_TEMPLATE/field_proposal.md
@@ -13,5 +13,20 @@ A clear and concise explanation of why you need this model field.
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
+| Field Name | Python Type | Description | Unique | Required | Index | Default Value |
+| ---------- | ----------- | ----------- | ------ | -------- | ----- | ------------- |
+
+**References**
+This project chooses field names based on industry consensus. List at least 3 real-world references showing how other projects name this field.
+
+| Source | Field Name Used | Link |
+| ------ | --------------- | ---- |
+| Example: Django auth | `is_active` | https://docs.djangoproject.com/en/stable/ref/contrib/auth/ |
+
+For enum fields, also list what values each source uses:
+
+| Source | Values |
+| ------ | ------ |
+
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/model_proposal.md
+++ b/.github/ISSUE_TEMPLATE/model_proposal.md
@@ -10,11 +10,24 @@ assignees: ''
 **Why do you need this model? What does it solve? Please describe.**
 A clear and concise explanation of why you need this model.
 
-**Details**
+**Fields**
 Write the fields that your proposed model must have in the table below or write a Pydantic model accordingly.
 
 | Field Name | Python Type | Description | Unique | Required | Index | Default Value |
 | ---------- | ----------- | ----------- | ------ | -------- | ----- | ------------- |
+
+**References**
+This project chooses field names and enum values based on industry consensus. List at least 3 real-world references showing how other projects, platforms, or frameworks name these fields.
+
+| Source | Field Names Used | Link |
+| ------ | ---------------- | ---- |
+| Example: GitHub Issues | `title`, `body`, `state` | https://docs.github.com/en/rest/issues |
+
+For enum fields (status, category, type, etc.), also list what values each source uses:
+
+| Source | Enum Field | Values |
+| ------ | ---------- | ------ |
+| Example: Zendesk | `status` | `new`, `open`, `pending`, `solved`, `closed` |
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ hatch run types:format
 hatch run pre
 ```
 
+## Philosophy
+
+This project ships **consensus-based defaults**. Field names, enum values, and behaviors are chosen by researching what popular platforms and frameworks do (GitHub, Zendesk, JIRA, Django, etc.), then picking the most common convention. When adding new mixins or fields, **research first, implement second** — proposals require at least 3 real-world references.
+
 ## Architecture
 
 **opinionated-mixins** provides reusable mixin classes for common model patterns (timestamps, UUIDs, soft-delete, etc.) with consistent interfaces across multiple Python ORMs and data frameworks.
@@ -51,27 +55,45 @@ hatch run pre
 src/opinionated_mixins/
 ├── __init__.py          # Package root
 ├── __about__.py         # Version (single source of truth for hatch)
+├── enums.py             # Shared enums used across all contrib modules
 └── contrib/             # Framework-specific implementations
     ├── pydantic/        # Pydantic BaseModel mixins
     ├── sqlalchemy/      # SQLAlchemy declarative mixins
-    ├── sqlmodel/        # SQLModel mixins
+    ├── sqlmodel/        # SQLModel mixins (re-exports from sqlalchemy)
     ├── mongoengine/     # MongoEngine Document mixins
     ├── odmantic/        # ODMantic Model mixins
     ├── wtforms/         # WTForms mixins
     └── dataclasses/     # stdlib dataclass mixins
 ```
 
-### Key Design Principle
+### Key Design Principles
 
-Each contrib module implements the **same set of mixins** with identical field names and behavior, adapted to its framework's idioms. For example, a `TimestampMixin` in `contrib/sqlalchemy/` should expose the same `created_at` and `updated_at` fields as its counterpart in `contrib/pydantic/`.
+- Each contrib module implements the **same set of mixins** with identical field names and behavior, adapted to its framework's idioms.
+- **SQLModel re-exports SQLAlchemy** — `contrib/sqlmodel/` simply re-exports from `contrib/sqlalchemy/` rather than duplicating implementations.
+- **Shared enums** live in `src/opinionated_mixins/enums.py`, not inside contrib modules. All frameworks import from there.
+
+### Framework Idiom Patterns
+
+Each framework expresses the same fields differently:
+
+- **SQLAlchemy**: `Column(String(255), nullable=False, index=True)`, uses `@declarative_mixin` and `__abstract__ = True`
+- **Pydantic**: `Field(..., min_length=1, max_length=255)` on `BaseModel`
+- **MongoEngine**: `StringField(required=True, max_length=255)` with `choices` for enums, uses `.value` for enum defaults
+- **ODMantic**: `Field(...)` similar to Pydantic syntax
+- **WTForms**: `StringField(label="...", validators=[...])` with `SelectField` for enums, uses `.value` for defaults/choices
+- **dataclasses**: `Annotated[str, Doc("...")]` with `dataclasses.field(default=...)`
 
 ### Contributing New Mixins
 
 When adding a mixin:
 
-1. Implement it in all applicable contrib modules with consistent field names
-2. Each contrib module's `__init__.py` is the sole file for that framework's mixins
-3. Use issue templates "Model Proposal" (for new mixin classes) and "Field Proposal" (for new fields on existing mixins)
+1. Research field names and enum values against real-world platforms (minimum 3 references)
+2. Add shared enums to `src/opinionated_mixins/enums.py`
+3. Implement in all applicable contrib modules with consistent field names
+4. Each mixin gets its own file per framework (e.g., `contrib/sqlalchemy/announcement.py`) and is re-exported from that framework's `__init__.py`
+5. For SQLModel, re-export the SQLAlchemy implementation
+6. Tests mirror the contrib structure: `tests/<framework>/test_<mixin>.py`
+7. Use issue templates "Model Proposal" (for new mixin classes) and "Field Proposal" (for new fields on existing mixins)
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -10,53 +10,82 @@
 [![Downloads/Month](https://pepy.tech/badge/opinionated-mixins/month)](https://pepy.tech/project/opinionated-mixins)
 [![Downloads/Week](https://pepy.tech/badge/opinionated-mixins/week)](https://pepy.tech/project/opinionated-mixins)
 
-Reusable mixin classes for common model patterns across multiple Python ORMs and data frameworks.
+Opinionated, consensus-driven model mixins — timestamps, feedback, announcements — consistent across Python ORMs and data frameworks.
 
-## Supported Frameworks
+## Why?
 
-| Framework       | Purpose                       |
-| --------------- | ----------------------------- |
-| **Pydantic**    | Data validation models        |
-| **SQLAlchemy**  | SQL ORM models                |
-| **SQLModel**    | Pydantic + SQLAlchemy hybrid  |
-| **MongoEngine** | MongoDB ODM                   |
-| **ODMantic**    | MongoDB async ODM             |
-| **WTForms**     | Form validation               |
-| **dataclasses** | Standard library data classes |
+Most projects need timestamps, soft-delete, announcements, feedback forms — and each time, you re-invent the field names, the enum values, the defaults. Should it be `created_at` or `date_created`? Is the status field called `state` or `status`? Is "resolved" a valid status or should it be "closed"?
 
-## What It Does
+**opinionated-mixins** makes these decisions for you, based on what the industry already agreed on.
 
-opinionated-mixins provides consistent interfaces for common model patterns, so you get the same fields and behavior regardless of which framework you use:
+Think of it like:
 
-- **Reusable model fields** (timestamps, UUIDs, soft-delete, etc.)
-- **Common model patterns** with consistent interfaces across frameworks
+- [**Mobbin**](https://mobbin.com/) — instead of designing UI patterns from scratch, you reference what top apps already do
+- [**shadcn/ui**](https://ui.shadcn.com/) — copy well-designed components into your project and customize from there
+- [**Bootstrap**](https://getbootstrap.com/) — standardized building blocks so teams stop bikeshedding
+
+Same idea, applied to data models. Use the standard way. Change it when you need it.
+
+## How It Works
+
+Every field name, enum value, and default is chosen by researching what popular platforms and frameworks do (GitHub, Zendesk, JIRA, Django packages, etc.), then picking the most common convention. Proposals require [at least 3 real-world references](.github/ISSUE_TEMPLATE/model_proposal.md).
+
+The same mixin is implemented across all supported frameworks with **identical field names and behavior**, adapted to each framework's idioms.
 
 ### Example
 
 ```python
-from opinionated_mixins.contrib.sqlalchemy import TimestampMixin, SoftDeleteMixin
+from opinionated_mixins.contrib.sqlalchemy import Announcement
 
-class User(Base, TimestampMixin, SoftDeleteMixin):
+class MyAnnouncement(Base, Announcement):
+    __tablename__ = "announcements"
     id = Column(Integer, primary_key=True)
-    name = Column(String)
-    # Automatically gets: created_at, updated_at, deleted_at, is_deleted
+    # Gets: title (str, indexed), content (text), category (enum)
 ```
 
----
+Switch to Pydantic? Same fields, same names:
 
-**Table of Contents**
+```python
+from opinionated_mixins.contrib.pydantic import Announcement
 
-- [opinionated-mixins](#opinionated-mixins)
-  - [Supported Frameworks](#supported-frameworks)
-  - [What It Does](#what-it-does)
-  - [Installation](#installation)
-  - [License](#license)
+class MyAnnouncement(Announcement):
+    id: int
+    # Same: title, content, category — with Pydantic validation
+```
+
+## Supported Frameworks
+
+| Framework       | Type                          | Use Case                      |
+| --------------- | ----------------------------- | ----------------------------- |
+| **SQLAlchemy**  | SQL ORM                       | Declarative model mixins      |
+| **SQLModel**    | SQL ORM (Pydantic + SA)       | Re-exports SQLAlchemy mixins  |
+| **Pydantic**    | Data validation               | BaseModel mixins with `Field` |
+| **MongoEngine** | MongoDB ODM                   | Document field mixins         |
+| **ODMantic**    | MongoDB async ODM             | Model field mixins            |
+| **WTForms**     | Form validation               | Form field mixins             |
+| **dataclasses** | Standard library              | `@dataclass` field mixins     |
+
+## Available Mixins
+
+| Mixin | Fields | Shared Enum |
+| ----- | ------ | ----------- |
+| **Announcement** | `title`, `content`, `category` | `AnnouncementCategory` (8 values) |
+
+More coming — see [open proposals](https://github.com/hasansezertasan/opinionated-mixins/issues?q=is%3Aopen+label%3Amodel-proposal).
 
 ## Installation
 
 ```console
 pip install opinionated-mixins
 ```
+
+Zero runtime dependencies. Framework packages (SQLAlchemy, Pydantic, etc.) are your responsibility — you already have them in your project.
+
+## Contributing
+
+New mixin ideas? Open a [Model Proposal](https://github.com/hasansezertasan/opinionated-mixins/issues/new?template=model_proposal.md). New fields on existing mixins? Open a [Field Proposal](https://github.com/hasansezertasan/opinionated-mixins/issues/new?template=field_proposal.md).
+
+Both require real-world references — this project runs on consensus, not opinion.
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,3 @@
+# TODO
+
+- What are our criteria for deciding on a contract / agreement / consensus mechanism?


### PR DESCRIPTION
## Summary

- Rewrite README with project motivation ("Why?"), consensus-driven approach, Mobbin/shadcn/Bootstrap analogies, supported frameworks table with use cases, and available mixins table
- Add philosophy section and framework idiom patterns to CLAUDE.md for contributor onboarding
- Add reference requirement sections to model and field proposal issue templates (minimum 3 real-world sources)
- Add TODO.md for tracking open design questions

## Test plan

- [x] No code changes — documentation only
- [ ] Verify issue template renders correctly on GitHub
- [ ] Review README rendering on GitHub/PyPI

## Summary by Sourcery

Revise and expand project documentation to clarify the library’s motivation, consensus-driven design, and contributor workflow, and strengthen issue templates with reference requirements.

Documentation:
- Rewrite README to explain the project’s purpose, consensus-based approach, supported frameworks, and available mixins with concrete examples and usage tables.
- Extend CLAUDE.md with project philosophy, shared enums, framework idioms, and more detailed guidelines for adding new mixins.

Chores:
- Introduce TODO.md to track open design questions about the project’s consensus mechanisms.