### PR TITLE
feat: add Person mixin across all contrib modules

### DIFF
--- a/src/opinionated_mixins/contrib/dataclasses/announcement.py
+++ b/src/opinionated_mixins/contrib/dataclasses/announcement.py
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 import dataclasses
-
-from typing_extensions import Annotated, Doc
+from typing import Annotated
 
 from opinionated_mixins.enums import AnnouncementCategory
+from typing_extensions import Doc
 
 
 @dataclasses.dataclass
@@ -15,5 +15,5 @@ class Announcement:
     title: Annotated[str, Doc("Title of the announcement")]
     content: Annotated[str, Doc("Content of the announcement")]
     category: Annotated[AnnouncementCategory, Doc("Category of the announcement")] = dataclasses.field(
-        default=AnnouncementCategory.GENERAL
+        default=AnnouncementCategory.GENERAL,
     )

--- a/src/opinionated_mixins/contrib/dataclasses/person.py
+++ b/src/opinionated_mixins/contrib/dataclasses/person.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import dataclasses
+import datetime
+from typing import Annotated
+
+from typing_extensions import Doc
+
+
+@dataclasses.dataclass
+class Person:
+    """Person mixin for stdlib dataclasses."""
+
+    first_name: Annotated[str, Doc("First name of the person")]
+    last_name: Annotated[str, Doc("Last name of the person")]
+    middle_name: Annotated[
+        str | None, Doc("Middle name of the person"),
+    ] = dataclasses.field(default=None)
+    phone_number: Annotated[
+        str | None, Doc("Phone number of the person"),
+    ] = dataclasses.field(default=None)
+    email: Annotated[
+        str | None, Doc("Email address of the person"),
+    ] = dataclasses.field(default=None)
+    street_address: Annotated[
+        str | None, Doc("Street address of the person"),
+    ] = dataclasses.field(default=None)
+    postal_code: Annotated[
+        str | None, Doc("Postal code of the person"),
+    ] = dataclasses.field(default=None)
+    city: Annotated[
+        str | None, Doc("City of the person"),
+    ] = dataclasses.field(default=None)
+    country: Annotated[
+        str | None,
+        Doc("Country of the person (ISO 3166-1 alpha-2)"),
+    ] = dataclasses.field(default=None)
+    date_of_birth: Annotated[
+        datetime.date | None, Doc("Birth date of the person"),
+    ] = dataclasses.field(default=None)
+    bio: Annotated[
+        str | None, Doc("Bio of the person"),
+    ] = dataclasses.field(default=None)

--- a/src/opinionated_mixins/contrib/mongoengine/__init__.py
+++ b/src/opinionated_mixins/contrib/mongoengine/__init__.py
@@ -2,3 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .person import Person as Person

--- a/src/opinionated_mixins/contrib/mongoengine/announcement.py
+++ b/src/opinionated_mixins/contrib/mongoengine/announcement.py
@@ -1,16 +1,17 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from typing import Any, ClassVar, Dict
+from typing import Any, ClassVar
+
+from opinionated_mixins.enums import AnnouncementCategory
 
 from mongoengine import StringField
-from opinionated_mixins.enums import AnnouncementCategory
 
 
 class Announcement:
     """Announcement mixin for MongoEngine documents."""
 
-    meta: ClassVar[Dict[str, Any]] = {"allow_inheritance": True}
+    meta: ClassVar[dict[str, Any]] = {"allow_inheritance": True}
 
     title = StringField(required=True, max_length=255)
     content = StringField(required=True)

--- a/src/opinionated_mixins/contrib/mongoengine/person.py
+++ b/src/opinionated_mixins/contrib/mongoengine/person.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from typing import Any, ClassVar
+
+from mongoengine import DateField, StringField
+
+
+class Person:
+    """Person mixin for MongoEngine documents."""
+
+    meta: ClassVar[dict[str, Any]] = {"allow_inheritance": True}
+
+    first_name = StringField(required=True, max_length=255)
+    last_name = StringField(required=True, max_length=255)
+    middle_name = StringField(required=False, max_length=255)
+    phone_number = StringField(required=False, max_length=20)
+    email = StringField(required=False, max_length=254)
+    street_address = StringField(required=False, max_length=255)
+    postal_code = StringField(required=False, max_length=20)
+    city = StringField(required=False, max_length=255)
+    country = StringField(required=False, max_length=2)
+    date_of_birth = DateField(required=False)
+    bio = StringField(required=False)

--- a/src/opinionated_mixins/contrib/odmantic/__init__.py
+++ b/src/opinionated_mixins/contrib/odmantic/__init__.py
@@ -2,3 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .person import Person as Person

--- a/src/opinionated_mixins/contrib/odmantic/announcement.py
+++ b/src/opinionated_mixins/contrib/odmantic/announcement.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from odmantic import Field
 from opinionated_mixins.enums import AnnouncementCategory
+
+from odmantic import Field
 
 
 class Announcement:

--- a/src/opinionated_mixins/contrib/odmantic/person.py
+++ b/src/opinionated_mixins/contrib/odmantic/person.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import datetime
+
+from odmantic import Field
+
+
+class Person:
+    """Person mixin for ODMantic models."""
+
+    first_name: str = Field(..., min_length=1, max_length=255)
+    last_name: str = Field(..., min_length=1, max_length=255)
+    middle_name: str | None = Field(default=None, max_length=255)
+    phone_number: str | None = Field(default=None, max_length=20)
+    email: str | None = Field(default=None, max_length=254)
+    street_address: str | None = Field(default=None, max_length=255)
+    postal_code: str | None = Field(default=None, max_length=20)
+    city: str | None = Field(default=None, max_length=255)
+    country: str | None = Field(default=None, min_length=2, max_length=2)
+    date_of_birth: datetime.date | None = Field(default=None)
+    bio: str | None = Field(default=None)

--- a/src/opinionated_mixins/contrib/pydantic/__init__.py
+++ b/src/opinionated_mixins/contrib/pydantic/__init__.py
@@ -2,3 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .person import Person as Person

--- a/src/opinionated_mixins/contrib/pydantic/announcement.py
+++ b/src/opinionated_mixins/contrib/pydantic/announcement.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import AnnouncementCategory
+
 from pydantic import BaseModel, Field
 
 

--- a/src/opinionated_mixins/contrib/pydantic/person.py
+++ b/src/opinionated_mixins/contrib/pydantic/person.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import datetime
+
+from pydantic import BaseModel, Field
+
+
+class Person(BaseModel):
+    """Person mixin for Pydantic models."""
+
+    first_name: str = Field(..., min_length=1, max_length=255)
+    last_name: str = Field(..., min_length=1, max_length=255)
+    middle_name: str | None = Field(default=None, max_length=255)
+    phone_number: str | None = Field(default=None, max_length=20)
+    email: str | None = Field(default=None, max_length=254)
+    street_address: str | None = Field(default=None, max_length=255)
+    postal_code: str | None = Field(default=None, max_length=20)
+    city: str | None = Field(default=None, max_length=255)
+    country: str | None = Field(default=None, min_length=2, max_length=2)
+    date_of_birth: datetime.date | None = Field(default=None)
+    bio: str | None = Field(default=None)

--- a/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
@@ -2,3 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .person import Person as Person

--- a/src/opinionated_mixins/contrib/sqlalchemy/announcement.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/announcement.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import AnnouncementCategory
+
 from sqlalchemy import Column, Enum, String, Text
 from sqlalchemy.orm import declarative_mixin
 

--- a/src/opinionated_mixins/contrib/sqlalchemy/person.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/person.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+from sqlalchemy import Column, Date, String, Text
+from sqlalchemy.orm import declarative_mixin
+
+
+@declarative_mixin
+class Person:
+    """Person mixin for SQLAlchemy models."""
+
+    __abstract__ = True
+
+    first_name = Column(String(255), nullable=False)
+    last_name = Column(String(255), nullable=False)
+    middle_name = Column(String(255), nullable=True)
+    phone_number = Column(String(20), nullable=True)
+    email = Column(String(254), nullable=True)
+    street_address = Column(String(255), nullable=True)
+    postal_code = Column(String(20), nullable=True)
+    city = Column(String(255), nullable=True)
+    country = Column(String(2), nullable=True)
+    date_of_birth = Column(Date, nullable=True)
+    bio = Column(Text, nullable=True)

--- a/src/opinionated_mixins/contrib/sqlmodel/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/__init__.py
@@ -2,3 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .person import Person as Person

--- a/src/opinionated_mixins/contrib/sqlmodel/person.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/person.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from .announcement import Announcement as Announcement
-from .person import Person as Person
+from opinionated_mixins.contrib.sqlalchemy.person import (
+    Person as Person,
+)

--- a/src/opinionated_mixins/contrib/wtforms/__init__.py
+++ b/src/opinionated_mixins/contrib/wtforms/__init__.py
@@ -2,3 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .person import Person as Person

--- a/src/opinionated_mixins/contrib/wtforms/announcement.py
+++ b/src/opinionated_mixins/contrib/wtforms/announcement.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import AnnouncementCategory
+
 from wtforms import SelectField, StringField, TextAreaField
 from wtforms.validators import DataRequired, Length
 

--- a/src/opinionated_mixins/contrib/wtforms/person.py
+++ b/src/opinionated_mixins/contrib/wtforms/person.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from wtforms import DateField, StringField, TextAreaField
+from wtforms.validators import DataRequired, Length, Optional
+
+
+class Person:
+    """Person mixin for WTForms forms."""
+
+    first_name = StringField(
+        label="First Name",
+        validators=[Length(min=1, max=255), DataRequired()],
+    )
+    last_name = StringField(
+        label="Last Name",
+        validators=[Length(min=1, max=255), DataRequired()],
+    )
+    middle_name = StringField(
+        label="Middle Name",
+        validators=[Length(max=255), Optional()],
+    )
+    phone_number = StringField(
+        label="Phone Number",
+        validators=[Length(max=20), Optional()],
+    )
+    email = StringField(
+        label="Email",
+        validators=[Length(max=254), Optional()],
+    )
+    street_address = StringField(
+        label="Street Address",
+        validators=[Length(max=255), Optional()],
+    )
+    postal_code = StringField(
+        label="Postal Code",
+        validators=[Length(max=20), Optional()],
+    )
+    city = StringField(
+        label="City",
+        validators=[Length(max=255), Optional()],
+    )
+    country = StringField(
+        label="Country",
+        validators=[Length(min=2, max=2), Optional()],
+    )
+    date_of_birth = DateField(
+        label="Date of Birth",
+        validators=[Optional()],
+    )
+    bio = TextAreaField(
+        label="Bio",
+        validators=[Optional()],
+    )

--- a/tests/dataclasses/test_person.py
+++ b/tests/dataclasses/test_person.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import dataclasses
+import datetime
+
+from opinionated_mixins.contrib.dataclasses import Person
+
+
+class TestDataclassesPerson:
+    def test_is_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(Person)
+
+    def test_create_with_required_only(self) -> None:
+        obj = Person(first_name="Jane", last_name="Doe")
+        assert obj.first_name == "Jane"
+        assert obj.last_name == "Doe"
+        assert obj.middle_name is None
+        assert obj.phone_number is None
+        assert obj.email is None
+        assert obj.street_address is None
+        assert obj.postal_code is None
+        assert obj.city is None
+        assert obj.country is None
+        assert obj.date_of_birth is None
+        assert obj.bio is None
+
+    def test_create_with_all_fields(self) -> None:
+        obj = Person(
+            first_name="Jane",
+            last_name="Doe",
+            middle_name="Marie",
+            phone_number="+1234567890",
+            email="jane@example.com",
+            street_address="123 Main St",
+            postal_code="10001",
+            city="New York",
+            country="US",
+            date_of_birth=datetime.date(1990, 5, 15),
+            bio="Software engineer",
+        )
+        assert obj.country == "US"
+        assert obj.date_of_birth == datetime.date(1990, 5, 15)
+
+    def test_fields(self) -> None:
+        fields = {f.name for f in dataclasses.fields(Person)}
+        expected = {
+            "first_name",
+            "last_name",
+            "middle_name",
+            "phone_number",
+            "email",
+            "street_address",
+            "postal_code",
+            "city",
+            "country",
+            "date_of_birth",
+            "bio",
+        }
+        assert fields == expected

--- a/tests/mongoengine/test_person.py
+++ b/tests/mongoengine/test_person.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.mongoengine import Person
+
+
+class TestMongoEnginePerson:
+    def test_has_first_name_field(self) -> None:
+        assert hasattr(Person, "first_name")
+        assert Person.first_name.required is True
+        assert Person.first_name.max_length == 255
+
+    def test_has_last_name_field(self) -> None:
+        assert hasattr(Person, "last_name")
+        assert Person.last_name.required is True
+        assert Person.last_name.max_length == 255
+
+    def test_has_middle_name_field(self) -> None:
+        assert hasattr(Person, "middle_name")
+        assert Person.middle_name.required is False
+        assert Person.middle_name.max_length == 255
+
+    def test_has_phone_number_field(self) -> None:
+        assert hasattr(Person, "phone_number")
+        assert Person.phone_number.required is False
+        assert Person.phone_number.max_length == 20
+
+    def test_has_email_field(self) -> None:
+        assert hasattr(Person, "email")
+        assert Person.email.required is False
+        assert Person.email.max_length == 254
+
+    def test_has_street_address_field(self) -> None:
+        assert hasattr(Person, "street_address")
+        assert Person.street_address.required is False
+        assert Person.street_address.max_length == 255
+
+    def test_has_postal_code_field(self) -> None:
+        assert hasattr(Person, "postal_code")
+        assert Person.postal_code.required is False
+        assert Person.postal_code.max_length == 20
+
+    def test_has_city_field(self) -> None:
+        assert hasattr(Person, "city")
+        assert Person.city.required is False
+        assert Person.city.max_length == 255
+
+    def test_has_country_field(self) -> None:
+        assert hasattr(Person, "country")
+        assert Person.country.required is False
+        assert Person.country.max_length == 2
+
+    def test_has_date_of_birth_field(self) -> None:
+        assert hasattr(Person, "date_of_birth")
+        assert Person.date_of_birth.required is False
+
+    def test_has_bio_field(self) -> None:
+        assert hasattr(Person, "bio")
+        assert Person.bio.required is False

--- a/tests/odmantic/test_person.py
+++ b/tests/odmantic/test_person.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.odmantic import Person
+
+
+class TestODManticPerson:
+    def test_has_expected_annotations(self) -> None:
+        annotations = Person.__annotations__
+        assert "first_name" in annotations
+        assert "last_name" in annotations
+        assert "middle_name" in annotations
+        assert "phone_number" in annotations
+        assert "email" in annotations
+        assert "street_address" in annotations
+        assert "postal_code" in annotations
+        assert "city" in annotations
+        assert "country" in annotations
+        assert "date_of_birth" in annotations
+        assert "bio" in annotations
+
+    def test_optional_fields_default_none(self) -> None:
+        for field_name in (
+            "middle_name",
+            "phone_number",
+            "email",
+            "street_address",
+            "postal_code",
+            "city",
+            "country",
+            "date_of_birth",
+            "bio",
+        ):
+            field_info = getattr(Person, field_name).pydantic_field_info
+            assert field_info.default is None, f"{field_name} should default to None"

--- a/tests/pydantic/test_announcement.py
+++ b/tests/pydantic/test_announcement.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 import pytest
-from pydantic import ValidationError
-
 from opinionated_mixins.contrib.pydantic import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
+from pydantic import ValidationError
 
 
 class TestPydanticAnnouncement:

--- a/tests/pydantic/test_person.py
+++ b/tests/pydantic/test_person.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import datetime
+
+import pytest
+from opinionated_mixins.contrib.pydantic import Person
+from pydantic import ValidationError
+
+
+class TestPydanticPerson:
+    def test_create_with_required_only(self) -> None:
+        obj = Person(first_name="Jane", last_name="Doe")
+        assert obj.first_name == "Jane"
+        assert obj.last_name == "Doe"
+        assert obj.middle_name is None
+        assert obj.phone_number is None
+        assert obj.email is None
+        assert obj.street_address is None
+        assert obj.postal_code is None
+        assert obj.city is None
+        assert obj.country is None
+        assert obj.date_of_birth is None
+        assert obj.bio is None
+
+    def test_create_with_all_fields(self) -> None:
+        obj = Person(
+            first_name="Jane",
+            last_name="Doe",
+            middle_name="Marie",
+            phone_number="+1234567890",
+            email="jane@example.com",
+            street_address="123 Main St",
+            postal_code="10001",
+            city="New York",
+            country="US",
+            date_of_birth=datetime.date(1990, 5, 15),
+            bio="Software engineer",
+        )
+        assert obj.middle_name == "Marie"
+        assert obj.country == "US"
+        assert obj.date_of_birth == datetime.date(1990, 5, 15)
+
+    def test_first_name_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Person(last_name="Doe")  # type: ignore[call-arg]
+
+    def test_last_name_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Person(first_name="Jane")  # type: ignore[call-arg]
+
+    def test_empty_first_name_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Person(first_name="", last_name="Doe")
+
+    def test_first_name_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            Person(first_name="x" * 256, last_name="Doe")
+
+    def test_country_must_be_two_chars(self) -> None:
+        with pytest.raises(ValidationError):
+            Person(first_name="Jane", last_name="Doe", country="USA")
+
+    def test_country_too_short(self) -> None:
+        with pytest.raises(ValidationError):
+            Person(first_name="Jane", last_name="Doe", country="U")
+
+    def test_phone_number_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            Person(first_name="Jane", last_name="Doe", phone_number="x" * 21)
+
+    def test_email_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            Person(first_name="Jane", last_name="Doe", email="x" * 255)

--- a/tests/sqlalchemy/test_announcement.py
+++ b/tests/sqlalchemy/test_announcement.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from sqlalchemy import Column, Integer, create_engine
-from sqlalchemy.orm import Session, declarative_base
-
 from opinionated_mixins.contrib.sqlalchemy import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, declarative_base
 
 Base = declarative_base()
 

--- a/tests/sqlalchemy/test_person.py
+++ b/tests/sqlalchemy/test_person.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import datetime
+
+from opinionated_mixins.contrib.sqlalchemy import Person
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+Base = declarative_base()
+
+
+class MyPerson(Person, Base):  # type: ignore[misc]
+    __tablename__ = "persons"
+    id = Column(Integer, primary_key=True)
+
+
+class TestSQLAlchemyPerson:
+    def setup_method(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+
+    def test_create_with_required_only(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyPerson(first_name="Jane", last_name="Doe")
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.first_name == "Jane"
+            assert obj.last_name == "Doe"
+            assert obj.middle_name is None
+            assert obj.phone_number is None
+            assert obj.email is None
+            assert obj.street_address is None
+            assert obj.postal_code is None
+            assert obj.city is None
+            assert obj.country is None
+            assert obj.date_of_birth is None
+            assert obj.bio is None
+
+    def test_create_with_all_fields(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyPerson(
+                first_name="Jane",
+                last_name="Doe",
+                middle_name="Marie",
+                phone_number="+1234567890",
+                email="jane@example.com",
+                street_address="123 Main St",
+                postal_code="10001",
+                city="New York",
+                country="US",
+                date_of_birth=datetime.date(1990, 5, 15),
+                bio="Software engineer",
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.middle_name == "Marie"
+            assert obj.phone_number == "+1234567890"
+            assert obj.email == "jane@example.com"
+            assert obj.street_address == "123 Main St"
+            assert obj.postal_code == "10001"
+            assert obj.city == "New York"
+            assert obj.country == "US"
+            assert obj.date_of_birth == datetime.date(1990, 5, 15)
+            assert obj.bio == "Software engineer"
+
+    def test_fields_exist(self) -> None:
+        columns = {c.name for c in MyPerson.__table__.columns}
+        expected = {
+            "first_name",
+            "last_name",
+            "middle_name",
+            "phone_number",
+            "email",
+            "street_address",
+            "postal_code",
+            "city",
+            "country",
+            "date_of_birth",
+            "bio",
+        }
+        assert expected.issubset(columns)

--- a/tests/sqlmodel/test_person.py
+++ b/tests/sqlmodel/test_person.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.sqlmodel import Person
+
+
+class TestSQLModelPerson:
+    def test_reexports_sqlalchemy(self) -> None:
+        from opinionated_mixins.contrib.sqlalchemy import (
+            Person as SAPerson,
+        )
+
+        assert Person is SAPerson

--- a/tests/wtforms/test_announcement.py
+++ b/tests/wtforms/test_announcement.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from wtforms import Form
-
 from opinionated_mixins.contrib.wtforms import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
+from wtforms import Form
 
 
 class AnnouncementForm(Announcement, Form):  # type: ignore[misc]
@@ -34,6 +33,6 @@ class TestWTFormsAnnouncement:
                 "title": "Test",
                 "content": "Hello world",
                 "category": "general",
-            }
+            },
         )
         assert form.validate()

--- a/tests/wtforms/test_person.py
+++ b/tests/wtforms/test_person.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.wtforms import Person
+from wtforms import Form
+
+
+class PersonForm(Person, Form):  # type: ignore[misc]
+    pass
+
+
+PERSON_FIELDS = {
+    "first_name",
+    "last_name",
+    "middle_name",
+    "phone_number",
+    "email",
+    "street_address",
+    "postal_code",
+    "city",
+    "country",
+    "date_of_birth",
+    "bio",
+}
+
+
+class TestWTFormsPerson:
+    def test_has_fields(self) -> None:
+        form = PersonForm()
+        for field_name in PERSON_FIELDS:
+            assert field_name in form._fields, f"Missing field: {field_name}"
+
+    def test_valid_submission_required_only(self) -> None:
+        form = PersonForm(
+            data={
+                "first_name": "Jane",
+                "last_name": "Doe",
+            },
+        )
+        assert form.validate()
+
+    def test_valid_submission_all_fields(self) -> None:
+        form = PersonForm(
+            data={
+                "first_name": "Jane",
+                "last_name": "Doe",
+                "middle_name": "Marie",
+                "phone_number": "+1234567890",
+                "email": "jane@example.com",
+                "street_address": "123 Main St",
+                "postal_code": "10001",
+                "city": "New York",
+                "country": "US",
+                "date_of_birth": "1990-05-15",
+                "bio": "Software engineer",
+            },
+        )
+        assert form.validate()
+
+    def test_missing_first_name_invalid(self) -> None:
+        form = PersonForm(
+            data={
+                "last_name": "Doe",
+            },
+        )
+        assert not form.validate()
+        assert "first_name" in form.errors
+
+    def test_missing_last_name_invalid(self) -> None:
+        form = PersonForm(
+            data={
+                "first_name": "Jane",
+            },
+        )
+        assert not form.validate()
+        assert "last_name" in form.errors


### PR DESCRIPTION
## Summary

- Add Person mixin with 11 fields implemented across all 7 contrib modules (SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, SQLModel re-export)
- Field names researched against OIDC, Django, Rails, Schema.org, Salesforce conventions: `date_of_birth`, `bio`, `phone_number`, `street_address`, `postal_code`
- Country field uses ISO 3166-1 alpha-2 (max 2 chars)

### Fields

| Field | Type | Required | Max Length |
|---|---|---|---|
| `first_name` | `str` | Yes | 255 |
| `last_name` | `str` | Yes | 255 |
| `middle_name` | `str` | No | 255 |
| `phone_number` | `str` | No | 20 |
| `email` | `str` | No | 254 (RFC 5321) |
| `street_address` | `str` | No | 255 |
| `postal_code` | `str` | No | 20 |
| `city` | `str` | No | 255 |
| `country` | `str` | No | 2 (ISO 3166-1 alpha-2) |
| `date_of_birth` | `date` | No | — |
| `bio` | `str` | No | — |

## Test plan

- [x] 36 new tests across all frameworks (66 total, all passing)
- [x] No regressions on existing Announcement tests
- [x] Lint clean (only pre-existing D100/PLC0414 warnings)

Closes #4

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a standardized `Person` mixin with 11 carefully researched fields (including `first_name`, `last_name`, `email`, `date_of_birth`, and address components) implemented consistently across all 7 supported framework integrations: SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, and SQLModel. The field specifications follow industry standards like OIDC and Schema.org, with the `country` field using ISO 3166-1 alpha-2 codes and `email` respecting RFC 5321 max length of 254 characters. Each implementation includes comprehensive test coverage (36 new tests) verifying field presence, validation rules, and optional/required behavior.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/opinionated_mixins/contrib/sqlalchemy/person.py` |
| 2 | `src/opinionated_mixins/contrib/pydantic/person.py` |
| 3 | `src/opinionated_mixins/contrib/mongoengine/person.py` |
| 4 | `src/opinionated_mixins/contrib/odmantic/person.py` |
| 5 | `src/opinionated_mixins/contrib/dataclasses/person.py` |
| 6 | `src/opinionated_mixins/contrib/wtforms/person.py` |
| 7 | `src/opinionated_mixins/contrib/sqlmodel/person.py` |
| 8 | `src/opinionated_mixins/contrib/sqlalchemy/__init__.py` |
| 9 | `src/opinionated_mixins/contrib/pydantic/__init__.py` |
| 10 | `src/opinionated_mixins/contrib/mongoengine/__init__.py` |
| 11 | `src/opinionated_mixins/contrib/odmantic/__init__.py` |
| 12 | `src/opinionated_mixins/contrib/dataclasses/__init__.py` |
| 13 | `src/opinionated_mixins/contrib/wtforms/__init__.py` |
| 14 | `src/opinionated_mixins/contrib/sqlmodel/__init__.py` |
| 15 | `tests/sqlalchemy/test_person.py` |
| 16 | `tests/pydantic/test_person.py` |
| 17 | `tests/mongoengine/test_person.py` |
| 18 | `tests/odmantic/test_person.py` |
| 19 | `tests/dataclasses/test_person.py` |
| 20 | `tests/wtforms/test_person.py` |
| 21 | `tests/sqlmodel/test_person.py` |
| 22 | `src/opinionated_mixins/contrib/dataclasses/announcement.py` |
| 23 | `src/opinionated_mixins/contrib/mongoengine/announcement.py` |
| 24 | `src/opinionated_mixins/contrib/odmantic/announcement.py` |
| 25 | `src/opinionated_mixins/contrib/pydantic/announcement.py` |
| 26 | `src/opinionated_mixins/contrib/sqlalchemy/announcement.py` |
| 27 | `tests/pydantic/test_announcement.py` |
| 28 | `tests/sqlalchemy/test_announcement.py` |
| 29 | `tests/wtforms/test_announcement.py` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `src/opinionated_mixins/contrib/dataclasses/announcement.py` | Import reorganization and formatting changes unrelated to Person mixin feature |
| `src/opinionated_mixins/contrib/mongoengine/announcement.py` | Import reorganization and type hint modernization (Dict -> dict) unrelated to Person mixin feature |
| `src/opinionated_mixins/contrib/odmantic/announcement.py` | Import reordering unrelated to Person mixin feature |
| `src/opinionated_mixins/contrib/pydantic/announcement.py` | Import reordering unrelated to Person mixin feature |
| `src/opinionated_mixins/contrib/sqlalchemy/announcement.py` | Import reordering unrelated to Person mixin feature |
| `tests/pydantic/test_announcement.py` | Import reordering unrelated to Person mixin feature |
| `tests/sqlalchemy/test_announcement.py` | Import reordering unrelated to Person mixin feature |
| `tests/wtforms/test_announcement.py` | Formatting change to data dictionary unrelated to Person mixin feature |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->