### PR TITLE
feat: add Feedback mixin across all contrib modules

### DIFF
--- a/src/opinionated_mixins/contrib/dataclasses/__init__.py
+++ b/src/opinionated_mixins/contrib/dataclasses/__init__.py
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .feedback import Feedback as Feedback
 from .person import Person as Person

--- a/src/opinionated_mixins/contrib/dataclasses/feedback.py
+++ b/src/opinionated_mixins/contrib/dataclasses/feedback.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import dataclasses
+from typing import Annotated
+
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+from typing_extensions import Doc
+
+
+@dataclasses.dataclass
+class Feedback:
+    """Feedback mixin for stdlib dataclasses."""
+
+    subject: Annotated[str, Doc("Subject of the feedback")]
+    content: Annotated[str, Doc("Content of the feedback")]
+    category: Annotated[FeedbackCategory, Doc("Category of the feedback")] = dataclasses.field(
+        default=FeedbackCategory.OTHER,
+    )
+    status: Annotated[FeedbackStatus, Doc("Status of the feedback")] = dataclasses.field(
+        default=FeedbackStatus.PENDING,
+    )

--- a/src/opinionated_mixins/contrib/dataclasses/feedback.py
+++ b/src/opinionated_mixins/contrib/dataclasses/feedback.py
@@ -14,9 +14,13 @@ class Feedback:
 
     subject: Annotated[str, Doc("Subject of the feedback")]
     content: Annotated[str, Doc("Content of the feedback")]
-    category: Annotated[FeedbackCategory, Doc("Category of the feedback")] = dataclasses.field(
-        default=FeedbackCategory.OTHER,
+    category: Annotated[FeedbackCategory, Doc("Category of the feedback")] = (
+        dataclasses.field(
+            default=FeedbackCategory.OTHER,
+        )
     )
-    status: Annotated[FeedbackStatus, Doc("Status of the feedback")] = dataclasses.field(
-        default=FeedbackStatus.PENDING,
+    status: Annotated[FeedbackStatus, Doc("Status of the feedback")] = (
+        dataclasses.field(
+            default=FeedbackStatus.PENDING,
+        )
     )

--- a/src/opinionated_mixins/contrib/mongoengine/__init__.py
+++ b/src/opinionated_mixins/contrib/mongoengine/__init__.py
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .feedback import Feedback as Feedback
 from .person import Person as Person

--- a/src/opinionated_mixins/contrib/mongoengine/feedback.py
+++ b/src/opinionated_mixins/contrib/mongoengine/feedback.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from typing import Any, ClassVar
+
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+from mongoengine import StringField
+
+
+class Feedback:
+    """Feedback mixin for MongoEngine documents."""
+
+    meta: ClassVar[dict[str, Any]] = {"allow_inheritance": True}
+
+    subject = StringField(required=True, max_length=255)
+    content = StringField(required=True)
+    category = StringField(
+        required=True,
+        default=FeedbackCategory.OTHER.value,
+        choices=[c.value for c in FeedbackCategory],
+    )
+    status = StringField(
+        required=True,
+        default=FeedbackStatus.PENDING.value,
+        choices=[c.value for c in FeedbackStatus],
+    )

--- a/src/opinionated_mixins/contrib/odmantic/__init__.py
+++ b/src/opinionated_mixins/contrib/odmantic/__init__.py
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .feedback import Feedback as Feedback
 from .person import Person as Person

--- a/src/opinionated_mixins/contrib/odmantic/feedback.py
+++ b/src/opinionated_mixins/contrib/odmantic/feedback.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+from odmantic import Field
+
+
+class Feedback:
+    """Feedback mixin for ODMantic models."""
+
+    subject: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(..., min_length=1)
+    category: FeedbackCategory = Field(default=FeedbackCategory.OTHER)
+    status: FeedbackStatus = Field(default=FeedbackStatus.PENDING)

--- a/src/opinionated_mixins/contrib/pydantic/__init__.py
+++ b/src/opinionated_mixins/contrib/pydantic/__init__.py
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .feedback import Feedback as Feedback
 from .person import Person as Person

--- a/src/opinionated_mixins/contrib/pydantic/feedback.py
+++ b/src/opinionated_mixins/contrib/pydantic/feedback.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+from pydantic import BaseModel, Field
+
+
+class Feedback(BaseModel):
+    """Feedback mixin for Pydantic models."""
+
+    subject: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(..., min_length=1)
+    category: FeedbackCategory = Field(default=FeedbackCategory.OTHER)
+    status: FeedbackStatus = Field(default=FeedbackStatus.PENDING)

--- a/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .feedback import Feedback as Feedback
 from .person import Person as Person

--- a/src/opinionated_mixins/contrib/sqlalchemy/feedback.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/feedback.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+from sqlalchemy import Column, Enum, String, Text
+from sqlalchemy.orm import declarative_mixin
+
+
+@declarative_mixin
+class Feedback:
+    """Feedback mixin for SQLAlchemy models."""
+
+    __abstract__ = True
+
+    subject = Column(String(255), nullable=False, index=True)
+    content = Column(Text, nullable=False)
+    category = Column(Enum(FeedbackCategory), nullable=False, default=FeedbackCategory.OTHER)
+    status = Column(Enum(FeedbackStatus), nullable=False, default=FeedbackStatus.PENDING)

--- a/src/opinionated_mixins/contrib/sqlalchemy/feedback.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/feedback.py
@@ -15,5 +15,9 @@ class Feedback:
 
     subject = Column(String(255), nullable=False, index=True)
     content = Column(Text, nullable=False)
-    category = Column(Enum(FeedbackCategory), nullable=False, default=FeedbackCategory.OTHER)
-    status = Column(Enum(FeedbackStatus), nullable=False, default=FeedbackStatus.PENDING)
+    category = Column(
+        Enum(FeedbackCategory), nullable=False, default=FeedbackCategory.OTHER
+    )
+    status = Column(
+        Enum(FeedbackStatus), nullable=False, default=FeedbackStatus.PENDING
+    )

--- a/src/opinionated_mixins/contrib/sqlmodel/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/__init__.py
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .feedback import Feedback as Feedback
 from .person import Person as Person

--- a/src/opinionated_mixins/contrib/sqlmodel/feedback.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/feedback.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.sqlalchemy.feedback import (
+    Feedback as Feedback,
+)

--- a/src/opinionated_mixins/contrib/wtforms/__init__.py
+++ b/src/opinionated_mixins/contrib/wtforms/__init__.py
@@ -2,4 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
+from .feedback import Feedback as Feedback
 from .person import Person as Person

--- a/src/opinionated_mixins/contrib/wtforms/feedback.py
+++ b/src/opinionated_mixins/contrib/wtforms/feedback.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+from wtforms import SelectField, StringField, TextAreaField
+from wtforms.validators import DataRequired, Length
+
+
+class Feedback:
+    """Feedback mixin for WTForms forms."""
+
+    subject = StringField(
+        label="Subject",
+        validators=[Length(min=1, max=255), DataRequired()],
+    )
+    content = TextAreaField(
+        label="Content",
+        validators=[DataRequired()],
+    )
+    category = SelectField(
+        label="Category",
+        choices=[(c.value, c.value.title()) for c in FeedbackCategory],
+        default=FeedbackCategory.OTHER.value,
+        validators=[DataRequired()],
+    )
+    status = SelectField(
+        label="Status",
+        choices=[(c.value, c.value.title()) for c in FeedbackStatus],
+        default=FeedbackStatus.PENDING.value,
+        validators=[DataRequired()],
+    )

--- a/src/opinionated_mixins/enums.py
+++ b/src/opinionated_mixins/enums.py
@@ -15,3 +15,21 @@ class AnnouncementCategory(str, enum.Enum):
     MAINTENANCE = "maintenance"
     UPDATE = "update"
     EVENT = "event"
+
+
+class FeedbackCategory(str, enum.Enum):
+    """Category of a feedback submission."""
+
+    BUG = "bug"
+    FEATURE = "feature"
+    IMPROVEMENT = "improvement"
+    OTHER = "other"
+
+
+class FeedbackStatus(str, enum.Enum):
+    """Status of a feedback submission."""
+
+    PENDING = "pending"
+    REVIEWED = "reviewed"
+    RESOLVED = "resolved"
+    DISMISSED = "dismissed"

--- a/tests/dataclasses/test_feedback.py
+++ b/tests/dataclasses/test_feedback.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import dataclasses
+
+from opinionated_mixins.contrib.dataclasses import Feedback
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+
+class TestDataclassesFeedback:
+    def test_is_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(Feedback)
+
+    def test_create_with_defaults(self) -> None:
+        obj = Feedback(subject="Bug report", content="Something broke")
+        assert obj.subject == "Bug report"
+        assert obj.content == "Something broke"
+        assert obj.category == FeedbackCategory.OTHER
+        assert obj.status == FeedbackStatus.PENDING
+
+    def test_create_with_explicit_values(self) -> None:
+        obj = Feedback(
+            subject="Feature idea",
+            content="Add dark mode",
+            category=FeedbackCategory.FEATURE,
+            status=FeedbackStatus.RESOLVED,
+        )
+        assert obj.category == FeedbackCategory.FEATURE
+        assert obj.status == FeedbackStatus.RESOLVED
+
+    def test_fields(self) -> None:
+        fields = {f.name for f in dataclasses.fields(Feedback)}
+        assert fields == {"subject", "content", "category", "status"}

--- a/tests/mongoengine/test_feedback.py
+++ b/tests/mongoengine/test_feedback.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.mongoengine import Feedback
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+
+class TestMongoEngineFeedback:
+    def test_has_subject_field(self) -> None:
+        assert hasattr(Feedback, "subject")
+        assert Feedback.subject.required is True
+        assert Feedback.subject.max_length == 255
+
+    def test_has_content_field(self) -> None:
+        assert hasattr(Feedback, "content")
+        assert Feedback.content.required is True
+
+    def test_has_category_field(self) -> None:
+        assert hasattr(Feedback, "category")
+        assert Feedback.category.required is True
+        assert Feedback.category.default == FeedbackCategory.OTHER.value
+
+    def test_category_choices(self) -> None:
+        choices = Feedback.category.choices
+        expected = [c.value for c in FeedbackCategory]
+        assert choices == expected
+
+    def test_has_status_field(self) -> None:
+        assert hasattr(Feedback, "status")
+        assert Feedback.status.required is True
+        assert Feedback.status.default == FeedbackStatus.PENDING.value
+
+    def test_status_choices(self) -> None:
+        choices = Feedback.status.choices
+        expected = [c.value for c in FeedbackStatus]
+        assert choices == expected

--- a/tests/odmantic/test_feedback.py
+++ b/tests/odmantic/test_feedback.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.odmantic import Feedback
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+
+class TestODManticFeedback:
+    def test_has_expected_annotations(self) -> None:
+        annotations = Feedback.__annotations__
+        assert "subject" in annotations
+        assert "content" in annotations
+        assert "category" in annotations
+        assert "status" in annotations
+
+    def test_category_default(self) -> None:
+        assert Feedback.category.pydantic_field_info.default == FeedbackCategory.OTHER
+
+    def test_status_default(self) -> None:
+        assert Feedback.status.pydantic_field_info.default == FeedbackStatus.PENDING

--- a/tests/pydantic/test_feedback.py
+++ b/tests/pydantic/test_feedback.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import pytest
+from opinionated_mixins.contrib.pydantic import Feedback
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+from pydantic import ValidationError
+
+
+class TestPydanticFeedback:
+    def test_create_with_defaults(self) -> None:
+        obj = Feedback(subject="Bug report", content="Something broke")
+        assert obj.subject == "Bug report"
+        assert obj.content == "Something broke"
+        assert obj.category == FeedbackCategory.OTHER
+        assert obj.status == FeedbackStatus.PENDING
+
+    def test_create_with_explicit_values(self) -> None:
+        obj = Feedback(
+            subject="Feature idea",
+            content="Add dark mode",
+            category=FeedbackCategory.FEATURE,
+            status=FeedbackStatus.REVIEWED,
+        )
+        assert obj.category == FeedbackCategory.FEATURE
+        assert obj.status == FeedbackStatus.REVIEWED
+
+    def test_subject_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Feedback(content="No subject")  # type: ignore[call-arg]
+
+    def test_content_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Feedback(subject="No content")  # type: ignore[call-arg]
+
+    def test_empty_subject_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Feedback(subject="", content="Body")
+
+    def test_subject_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            Feedback(subject="x" * 256, content="Body")
+
+    def test_category_from_string(self) -> None:
+        obj = Feedback(subject="Test", content="Body", category="bug")  # type: ignore[arg-type]
+        assert obj.category == FeedbackCategory.BUG
+
+    def test_invalid_category_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Feedback(subject="Test", content="Body", category="invalid")  # type: ignore[arg-type]
+
+    def test_status_from_string(self) -> None:
+        obj = Feedback(subject="Test", content="Body", status="reviewed")  # type: ignore[arg-type]
+        assert obj.status == FeedbackStatus.REVIEWED
+
+    def test_invalid_status_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Feedback(subject="Test", content="Body", status="invalid")  # type: ignore[arg-type]

--- a/tests/sqlalchemy/test_feedback.py
+++ b/tests/sqlalchemy/test_feedback.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.sqlalchemy import Feedback
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+Base = declarative_base()
+
+
+class MyFeedback(Feedback, Base):  # type: ignore[misc]
+    __tablename__ = "feedbacks"
+    id = Column(Integer, primary_key=True)
+
+
+class TestSQLAlchemyFeedback:
+    def setup_method(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+
+    def test_create_with_defaults(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyFeedback(subject="Bug report", content="Something broke")
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.subject == "Bug report"
+            assert obj.content == "Something broke"
+            assert obj.category == FeedbackCategory.OTHER
+            assert obj.status == FeedbackStatus.PENDING
+
+    def test_create_with_explicit_values(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyFeedback(
+                subject="Feature idea",
+                content="Add dark mode",
+                category=FeedbackCategory.FEATURE,
+                status=FeedbackStatus.REVIEWED,
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.category == FeedbackCategory.FEATURE
+            assert obj.status == FeedbackStatus.REVIEWED
+
+    def test_subject_indexed(self) -> None:
+        table = MyFeedback.__table__
+        indexed_columns = {col.name for idx in table.indexes for col in idx.columns}
+        assert "subject" in indexed_columns
+
+    def test_fields_exist(self) -> None:
+        columns = {c.name for c in MyFeedback.__table__.columns}
+        assert {"subject", "content", "category", "status"}.issubset(columns)

--- a/tests/sqlmodel/test_feedback.py
+++ b/tests/sqlmodel/test_feedback.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.sqlmodel import Feedback
+
+
+class TestSQLModelFeedback:
+    def test_reexports_sqlalchemy(self) -> None:
+        from opinionated_mixins.contrib.sqlalchemy import Feedback as SAFeedback
+
+        assert Feedback is SAFeedback

--- a/tests/wtforms/test_feedback.py
+++ b/tests/wtforms/test_feedback.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.wtforms import Feedback
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+from wtforms import Form
+
+
+class FeedbackForm(Feedback, Form):  # type: ignore[misc]
+    pass
+
+
+class TestWTFormsFeedback:
+    def test_has_fields(self) -> None:
+        form = FeedbackForm()
+        assert "subject" in form._fields
+        assert "content" in form._fields
+        assert "category" in form._fields
+        assert "status" in form._fields
+
+    def test_category_choices(self) -> None:
+        form = FeedbackForm()
+        choice_values = [c[0] for c in form.category.choices]
+        expected = [c.value for c in FeedbackCategory]
+        assert choice_values == expected
+
+    def test_category_default(self) -> None:
+        form = FeedbackForm()
+        assert form.category.default == FeedbackCategory.OTHER.value
+
+    def test_status_choices(self) -> None:
+        form = FeedbackForm()
+        choice_values = [c[0] for c in form.status.choices]
+        expected = [c.value for c in FeedbackStatus]
+        assert choice_values == expected
+
+    def test_status_default(self) -> None:
+        form = FeedbackForm()
+        assert form.status.default == FeedbackStatus.PENDING.value
+
+    def test_valid_submission(self) -> None:
+        form = FeedbackForm(
+            data={
+                "subject": "Bug report",
+                "content": "Something broke",
+                "category": "bug",
+                "status": "pending",
+            },
+        )
+        assert form.validate()


### PR DESCRIPTION
## Summary

- Add `FeedbackCategory` and `FeedbackStatus` enums to shared `enums.py`
- Implement Feedback mixin (subject, content, category, status) across all 7 frameworks: SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, SQLModel
- Add 34 tests covering defaults, explicit values, validation, and framework-specific behaviors

Closes #6

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Body field name | `content` | Matches Announcement mixin; consistent with Zendesk/Intercom |
| Category values | `bug`, `feature`, `improvement`, `other` | YAGNI — minimal set covers 90% of cases |
| Status values | `pending`, `reviewed`, `resolved`, `dismissed` | Simple lifecycle, not issue-tracker semantics |
| `is_read` field | Dropped | Status enum handles read/unread; avoids dual-state ambiguity |

## Test plan

- [x] All 100 tests pass (`uv run pytest tests -v`)
- [x] No new lint regressions (`uv run ruff check .`)
- [x] Format clean for new files (`uv run ruff format --check .`)
- [x] mypy errors match pre-existing pattern (SA `declarative_mixin` stubs)

## Summary by Sourcery

Introduce a shared feedback model with consistent fields and enums across all supported frameworks.

New Features:
- Add FeedbackCategory and FeedbackStatus enums to the shared enum module for classifying and tracking feedback.
- Provide Feedback mixin/model implementations for SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, stdlib dataclasses, and SQLModel (via SQLAlchemy re-export) with aligned subject/content/category/status fields.

Tests:
- Add framework-specific feedback tests validating required fields, defaults, enum choices, and basic integration for Pydantic, SQLAlchemy, MongoEngine, ODMantic, WTForms, dataclasses, and SQLModel.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a new `Feedback` mixin across all seven supported framework integrations (SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, and SQLModel). The mixin provides a standardized feedback submission model with four core fields: `subject`, `content`, `category` (bug, feature, improvement, or other), and `status` (pending, reviewed, resolved, or dismissed). Two new enums (`FeedbackCategory` and `FeedbackStatus`) are added to the shared enums module to support these fields. The implementation includes 34 tests covering defaults, explicit values, validation, and framework-specific behaviors.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/opinionated_mixins/enums.py` |
| 2 | `src/opinionated_mixins/contrib/pydantic/feedback.py` |
| 3 | `src/opinionated_mixins/contrib/dataclasses/feedback.py` |
| 4 | `src/opinionated_mixins/contrib/odmantic/feedback.py` |
| 5 | `src/opinionated_mixins/contrib/sqlalchemy/feedback.py` |
| 6 | `src/opinionated_mixins/contrib/mongoengine/feedback.py` |
| 7 | `src/opinionated_mixins/contrib/wtforms/feedback.py` |
| 8 | `src/opinionated_mixins/contrib/sqlmodel/feedback.py` |
| 9 | `src/opinionated_mixins/contrib/pydantic/__init__.py` |
| 10 | `src/opinionated_mixins/contrib/dataclasses/__init__.py` |
| 11 | `src/opinionated_mixins/contrib/odmantic/__init__.py` |
| 12 | `src/opinionated_mixins/contrib/sqlalchemy/__init__.py` |
| 13 | `src/opinionated_mixins/contrib/mongoengine/__init__.py` |
| 14 | `src/opinionated_mixins/contrib/wtforms/__init__.py` |
| 15 | `src/opinionated_mixins/contrib/sqlmodel/__init__.py` |
| 16 | `tests/pydantic/test_feedback.py` |
| 17 | `tests/sqlalchemy/test_feedback.py` |
| 18 | `tests/dataclasses/test_feedback.py` |
| 19 | `tests/odmantic/test_feedback.py` |
| 20 | `tests/mongoengine/test_feedback.py` |
| 21 | `tests/wtforms/test_feedback.py` |
| 22 | `tests/sqlmodel/test_feedback.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->