### PR TITLE
feat: add Template mixin across all contrib modules

### DIFF
--- a/src/opinionated_mixins/contrib/dataclasses/__init__.py
+++ b/src/opinionated_mixins/contrib/dataclasses/__init__.py
@@ -4,3 +4,4 @@
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
 from .person import Person as Person
+from .template import Template as Template

--- a/src/opinionated_mixins/contrib/dataclasses/template.py
+++ b/src/opinionated_mixins/contrib/dataclasses/template.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import dataclasses
+from typing import Annotated
+
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+from typing_extensions import Doc
+
+
+@dataclasses.dataclass
+class Template:
+    """Template mixin for stdlib dataclasses."""
+
+    name: Annotated[str, Doc("Name of the template")]
+    content: Annotated[str, Doc("Content of the template")]
+    format: Annotated[TemplateFormat, Doc("Format of the template")] = dataclasses.field(
+        default=TemplateFormat.PLAIN,
+    )
+    type: Annotated[TemplateType, Doc("Type of the template")] = dataclasses.field(
+        default=TemplateType.OTHER,
+    )

--- a/src/opinionated_mixins/contrib/mongoengine/__init__.py
+++ b/src/opinionated_mixins/contrib/mongoengine/__init__.py
@@ -4,3 +4,4 @@
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
 from .person import Person as Person
+from .template import Template as Template

--- a/src/opinionated_mixins/contrib/mongoengine/template.py
+++ b/src/opinionated_mixins/contrib/mongoengine/template.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from typing import Any, ClassVar
+
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+from mongoengine import StringField
+
+
+class Template:
+    """Template mixin for MongoEngine documents."""
+
+    meta: ClassVar[dict[str, Any]] = {"allow_inheritance": True}
+
+    name = StringField(required=True, max_length=255)
+    content = StringField(required=True)
+    format = StringField(
+        required=True,
+        default=TemplateFormat.PLAIN.value,
+        choices=[c.value for c in TemplateFormat],
+    )
+    type = StringField(
+        required=True,
+        default=TemplateType.OTHER.value,
+        choices=[c.value for c in TemplateType],
+    )

--- a/src/opinionated_mixins/contrib/odmantic/__init__.py
+++ b/src/opinionated_mixins/contrib/odmantic/__init__.py
@@ -4,3 +4,4 @@
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
 from .person import Person as Person
+from .template import Template as Template

--- a/src/opinionated_mixins/contrib/odmantic/template.py
+++ b/src/opinionated_mixins/contrib/odmantic/template.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+from odmantic import Field
+
+
+class Template:
+    """Template mixin for ODMantic models."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(..., min_length=1)
+    format: TemplateFormat = Field(default=TemplateFormat.PLAIN)
+    type: TemplateType = Field(default=TemplateType.OTHER)

--- a/src/opinionated_mixins/contrib/pydantic/__init__.py
+++ b/src/opinionated_mixins/contrib/pydantic/__init__.py
@@ -4,3 +4,4 @@
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
 from .person import Person as Person
+from .template import Template as Template

--- a/src/opinionated_mixins/contrib/pydantic/template.py
+++ b/src/opinionated_mixins/contrib/pydantic/template.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+from pydantic import BaseModel, Field
+
+
+class Template(BaseModel):
+    """Template mixin for Pydantic models."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(..., min_length=1)
+    format: TemplateFormat = Field(default=TemplateFormat.PLAIN)
+    type: TemplateType = Field(default=TemplateType.OTHER)

--- a/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
@@ -4,3 +4,4 @@
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
 from .person import Person as Person
+from .template import Template as Template

--- a/src/opinionated_mixins/contrib/sqlalchemy/feedback.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/feedback.py
@@ -16,8 +16,8 @@ class Feedback:
     subject = Column(String(255), nullable=False, index=True)
     content = Column(Text, nullable=False)
     category = Column(
-        Enum(FeedbackCategory), nullable=False, default=FeedbackCategory.OTHER
+        Enum(FeedbackCategory), nullable=False, default=FeedbackCategory.OTHER,
     )
     status = Column(
-        Enum(FeedbackStatus), nullable=False, default=FeedbackStatus.PENDING
+        Enum(FeedbackStatus), nullable=False, default=FeedbackStatus.PENDING,
     )

--- a/src/opinionated_mixins/contrib/sqlalchemy/template.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/template.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+from sqlalchemy import Column, Enum, String, Text
+from sqlalchemy.orm import declarative_mixin
+
+
+@declarative_mixin
+class Template:
+    """Template mixin for SQLAlchemy models."""
+
+    __abstract__ = True
+
+    name = Column(String(255), nullable=False, index=True)
+    content = Column(Text, nullable=False)
+    format = Column(Enum(TemplateFormat), nullable=False, default=TemplateFormat.PLAIN)
+    type = Column(Enum(TemplateType), nullable=False, default=TemplateType.OTHER)

--- a/src/opinionated_mixins/contrib/sqlmodel/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/__init__.py
@@ -4,3 +4,4 @@
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
 from .person import Person as Person
+from .template import Template as Template

--- a/src/opinionated_mixins/contrib/sqlmodel/template.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/template.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.sqlalchemy.template import (
+    Template as Template,
+)

--- a/src/opinionated_mixins/contrib/wtforms/__init__.py
+++ b/src/opinionated_mixins/contrib/wtforms/__init__.py
@@ -4,3 +4,4 @@
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
 from .person import Person as Person
+from .template import Template as Template

--- a/src/opinionated_mixins/contrib/wtforms/template.py
+++ b/src/opinionated_mixins/contrib/wtforms/template.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+from wtforms import SelectField, StringField, TextAreaField
+from wtforms.validators import DataRequired, Length
+
+
+class Template:
+    """Template mixin for WTForms forms."""
+
+    name = StringField(
+        label="Name",
+        validators=[Length(min=1, max=255), DataRequired()],
+    )
+    content = TextAreaField(
+        label="Content",
+        validators=[DataRequired()],
+    )
+    format = SelectField(
+        label="Format",
+        choices=[(c.value, c.value.title()) for c in TemplateFormat],
+        default=TemplateFormat.PLAIN.value,
+        validators=[DataRequired()],
+    )
+    type = SelectField(
+        label="Type",
+        choices=[(c.value, c.value.title()) for c in TemplateType],
+        default=TemplateType.OTHER.value,
+        validators=[DataRequired()],
+    )

--- a/src/opinionated_mixins/enums.py
+++ b/src/opinionated_mixins/enums.py
@@ -17,6 +17,23 @@ class AnnouncementCategory(str, enum.Enum):
     EVENT = "event"
 
 
+class TemplateFormat(str, enum.Enum):
+    """Format of a template's content."""
+
+    PLAIN = "plain"
+    HTML = "html"
+    MARKDOWN = "markdown"
+
+
+class TemplateType(str, enum.Enum):
+    """Type/purpose of a template."""
+
+    EMAIL = "email"
+    SMS = "sms"
+    PUSH = "push"
+    OTHER = "other"
+
+
 class FeedbackCategory(str, enum.Enum):
     """Category of a feedback submission."""
 

--- a/tests/dataclasses/test_template.py
+++ b/tests/dataclasses/test_template.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import dataclasses
+
+from opinionated_mixins.contrib.dataclasses import Template
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+
+class TestDataclassesTemplate:
+    def test_is_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(Template)
+
+    def test_create_with_defaults(self) -> None:
+        obj = Template(name="Welcome", content="Hello {{name}}")
+        assert obj.name == "Welcome"
+        assert obj.content == "Hello {{name}}"
+        assert obj.format == TemplateFormat.PLAIN
+        assert obj.type == TemplateType.OTHER
+
+    def test_create_with_explicit_values(self) -> None:
+        obj = Template(
+            name="Newsletter",
+            content="<h1>News</h1>",
+            format=TemplateFormat.HTML,
+            type=TemplateType.EMAIL,
+        )
+        assert obj.format == TemplateFormat.HTML
+        assert obj.type == TemplateType.EMAIL
+
+    def test_fields(self) -> None:
+        fields = {f.name for f in dataclasses.fields(Template)}
+        assert fields == {"name", "content", "format", "type"}

--- a/tests/mongoengine/test_template.py
+++ b/tests/mongoengine/test_template.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.mongoengine import Template
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+
+class TestMongoEngineTemplate:
+    def test_has_name_field(self) -> None:
+        assert hasattr(Template, "name")
+        assert Template.name.required is True
+        assert Template.name.max_length == 255
+
+    def test_has_content_field(self) -> None:
+        assert hasattr(Template, "content")
+        assert Template.content.required is True
+
+    def test_has_format_field(self) -> None:
+        assert hasattr(Template, "format")
+        assert Template.format.required is True
+        assert Template.format.default == TemplateFormat.PLAIN.value
+
+    def test_format_choices(self) -> None:
+        choices = Template.format.choices
+        expected = [c.value for c in TemplateFormat]
+        assert choices == expected
+
+    def test_has_type_field(self) -> None:
+        assert hasattr(Template, "type")
+        assert Template.type.required is True
+        assert Template.type.default == TemplateType.OTHER.value
+
+    def test_type_choices(self) -> None:
+        choices = Template.type.choices
+        expected = [c.value for c in TemplateType]
+        assert choices == expected

--- a/tests/odmantic/test_template.py
+++ b/tests/odmantic/test_template.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.odmantic import Template
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+
+class TestODManticTemplate:
+    def test_has_expected_annotations(self) -> None:
+        annotations = Template.__annotations__
+        assert "name" in annotations
+        assert "content" in annotations
+        assert "format" in annotations
+        assert "type" in annotations
+
+    def test_format_default(self) -> None:
+        assert Template.format.pydantic_field_info.default == TemplateFormat.PLAIN
+
+    def test_type_default(self) -> None:
+        assert Template.type.pydantic_field_info.default == TemplateType.OTHER

--- a/tests/pydantic/test_template.py
+++ b/tests/pydantic/test_template.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+import pytest
+from opinionated_mixins.contrib.pydantic import Template
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+from pydantic import ValidationError
+
+
+class TestPydanticTemplate:
+    def test_create_with_defaults(self) -> None:
+        obj = Template(name="Welcome", content="Hello {{name}}")
+        assert obj.name == "Welcome"
+        assert obj.content == "Hello {{name}}"
+        assert obj.format == TemplateFormat.PLAIN
+        assert obj.type == TemplateType.OTHER
+
+    def test_create_with_explicit_values(self) -> None:
+        obj = Template(
+            name="Newsletter",
+            content="<h1>News</h1>",
+            format=TemplateFormat.HTML,
+            type=TemplateType.EMAIL,
+        )
+        assert obj.format == TemplateFormat.HTML
+        assert obj.type == TemplateType.EMAIL
+
+    def test_name_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Template(content="No name")  # type: ignore[call-arg]
+
+    def test_content_required(self) -> None:
+        with pytest.raises(ValidationError):
+            Template(name="No content")  # type: ignore[call-arg]
+
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Template(name="", content="Body")
+
+    def test_name_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            Template(name="x" * 256, content="Body")
+
+    def test_format_from_string(self) -> None:
+        obj = Template(name="Test", content="Body", format="html")  # type: ignore[arg-type]
+        assert obj.format == TemplateFormat.HTML
+
+    def test_invalid_format_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Template(name="Test", content="Body", format="invalid")  # type: ignore[arg-type]
+
+    def test_type_from_string(self) -> None:
+        obj = Template(name="Test", content="Body", type="sms")  # type: ignore[arg-type]
+        assert obj.type == TemplateType.SMS
+
+    def test_invalid_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Template(name="Test", content="Body", type="invalid")  # type: ignore[arg-type]

--- a/tests/sqlalchemy/test_template.py
+++ b/tests/sqlalchemy/test_template.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.sqlalchemy import Template
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+Base = declarative_base()
+
+
+class MyTemplate(Template, Base):  # type: ignore[misc]
+    __tablename__ = "templates"
+    id = Column(Integer, primary_key=True)
+
+
+class TestSQLAlchemyTemplate:
+    def setup_method(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+
+    def test_create_with_defaults(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyTemplate(name="Welcome Email", content="Hello {{name}}")
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.name == "Welcome Email"
+            assert obj.content == "Hello {{name}}"
+            assert obj.format == TemplateFormat.PLAIN
+            assert obj.type == TemplateType.OTHER
+
+    def test_create_with_explicit_values(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyTemplate(
+                name="Newsletter",
+                content="<h1>News</h1>",
+                format=TemplateFormat.HTML,
+                type=TemplateType.EMAIL,
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.format == TemplateFormat.HTML
+            assert obj.type == TemplateType.EMAIL
+
+    def test_name_indexed(self) -> None:
+        table = MyTemplate.__table__
+        indexed_columns = {col.name for idx in table.indexes for col in idx.columns}
+        assert "name" in indexed_columns
+
+    def test_fields_exist(self) -> None:
+        columns = {c.name for c in MyTemplate.__table__.columns}
+        assert {"name", "content", "format", "type"}.issubset(columns)

--- a/tests/sqlmodel/test_template.py
+++ b/tests/sqlmodel/test_template.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.sqlmodel import Template
+
+
+class TestSQLModelTemplate:
+    def test_reexports_sqlalchemy(self) -> None:
+        from opinionated_mixins.contrib.sqlalchemy import (
+            Template as SATemplate,
+        )
+
+        assert Template is SATemplate

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-from opinionated_mixins.enums import AnnouncementCategory
+from opinionated_mixins.enums import AnnouncementCategory, TemplateFormat, TemplateType
 
 
 class TestAnnouncementCategory:
@@ -24,3 +24,29 @@ class TestAnnouncementCategory:
 
     def test_lookup_by_value(self) -> None:
         assert AnnouncementCategory("warning") is AnnouncementCategory.WARNING
+
+
+class TestTemplateFormat:
+    def test_values(self) -> None:
+        expected = ["plain", "html", "markdown"]
+        assert [c.value for c in TemplateFormat] == expected
+
+    def test_str_mixin(self) -> None:
+        assert TemplateFormat.PLAIN == "plain"
+        assert isinstance(TemplateFormat.HTML, str)
+
+    def test_lookup_by_value(self) -> None:
+        assert TemplateFormat("html") is TemplateFormat.HTML
+
+
+class TestTemplateType:
+    def test_values(self) -> None:
+        expected = ["email", "sms", "push", "other"]
+        assert [c.value for c in TemplateType] == expected
+
+    def test_str_mixin(self) -> None:
+        assert TemplateType.EMAIL == "email"
+        assert isinstance(TemplateType.SMS, str)
+
+    def test_lookup_by_value(self) -> None:
+        assert TemplateType("push") is TemplateType.PUSH

--- a/tests/wtforms/test_template.py
+++ b/tests/wtforms/test_template.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+from opinionated_mixins.contrib.wtforms import Template
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+from wtforms import Form
+
+
+class TemplateForm(Template, Form):  # type: ignore[misc]
+    pass
+
+
+class TestWTFormsTemplate:
+    def test_has_fields(self) -> None:
+        form = TemplateForm()
+        assert "name" in form._fields
+        assert "content" in form._fields
+        assert "format" in form._fields
+        assert "type" in form._fields
+
+    def test_format_choices(self) -> None:
+        form = TemplateForm()
+        choice_values = [c[0] for c in form.format.choices]
+        expected = [c.value for c in TemplateFormat]
+        assert choice_values == expected
+
+    def test_format_default(self) -> None:
+        form = TemplateForm()
+        assert form.format.default == TemplateFormat.PLAIN.value
+
+    def test_type_choices(self) -> None:
+        form = TemplateForm()
+        choice_values = [c[0] for c in form.type.choices]
+        expected = [c.value for c in TemplateType]
+        assert choice_values == expected
+
+    def test_type_default(self) -> None:
+        form = TemplateForm()
+        assert form.type.default == TemplateType.OTHER.value
+
+    def test_valid_submission(self) -> None:
+        form = TemplateForm(
+            data={
+                "name": "Welcome",
+                "content": "Hello {{name}}",
+                "format": "plain",
+                "type": "email",
+            },
+        )
+        assert form.validate()


### PR DESCRIPTION
## Summary

- Add `Template` mixin with `name`, `content`, `format`, and `type` fields across all 7 contrib modules (SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, SQLModel)
- Add `TemplateFormat` (plain, html, markdown) and `TemplateType` (email, sms, push, other) enums to shared `enums.py`
- Add tests for all frameworks and new enums (140 total tests pass)

Closes #7

## Test plan

- [x] All 140 tests pass (`uv run pytest tests -v`)
- [x] Enum tests verify values, string mixin, and lookup by value
- [x] SQLAlchemy tests verify defaults, explicit values, index on `name`, and field existence
- [x] Pydantic tests verify validation (required, min/max length, enum coercion, invalid rejection)
- [x] MongoEngine tests verify field properties, defaults, and choices
- [x] ODMantic tests verify annotations and defaults
- [x] WTForms tests verify fields, choices, defaults, and form validation
- [x] dataclasses tests verify dataclass decorator, defaults, explicit values, and fields
- [x] SQLModel tests verify re-export from SQLAlchemy

## Summary by Sourcery

Introduce a reusable Template mixin with standardized fields across supported frameworks, backed by shared enums for template format and type, and cover the new functionality with tests.

New Features:
- Add Template mixin with name, content, format, and type fields for SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, stdlib dataclasses, and SQLModel models and forms.
- Introduce TemplateFormat and TemplateType enums to centralize template content formats and template usage types across frameworks.

Tests:
- Add unit tests for Template enums to verify values, string behavior, and lookup by value.
- Add framework-specific tests for the Template mixin across SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, and SQLModel to validate fields, defaults, choices, validation, and re-export behavior.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new `Template` mixin across all 7 contrib modules (SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, and SQLModel). The mixin provides four fields: `name`, `content`, `format`, and `type`. Two new enums (`TemplateFormat` and `TemplateType`) are introduced in the shared enums module to support format options (plain, html, markdown) and type categorization (email, sms, push, other). Each implementation is framework-specific with appropriate defaults, validation, and constraints, and comprehensive test coverage is included for all frameworks.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/opinionated_mixins/enums.py` |
| 2 | `tests/test_enums.py` |
| 3 | `src/opinionated_mixins/contrib/pydantic/template.py` |
| 4 | `tests/pydantic/test_template.py` |
| 5 | `src/opinionated_mixins/contrib/dataclasses/template.py` |
| 6 | `tests/dataclasses/test_template.py` |
| 7 | `src/opinionated_mixins/contrib/sqlalchemy/template.py` |
| 8 | `tests/sqlalchemy/test_template.py` |
| 9 | `src/opinionated_mixins/contrib/sqlmodel/template.py` |
| 10 | `tests/sqlmodel/test_template.py` |
| 11 | `src/opinionated_mixins/contrib/mongoengine/template.py` |
| 12 | `tests/mongoengine/test_template.py` |
| 13 | `src/opinionated_mixins/contrib/odmantic/template.py` |
| 14 | `tests/odmantic/test_template.py` |
| 15 | `src/opinionated_mixins/contrib/wtforms/template.py` |
| 16 | `tests/wtforms/test_template.py` |
| 17 | `src/opinionated_mixins/contrib/dataclasses/__init__.py` |
| 18 | `src/opinionated_mixins/contrib/pydantic/__init__.py` |
| 19 | `src/opinionated_mixins/contrib/sqlalchemy/__init__.py` |
| 20 | `src/opinionated_mixins/contrib/sqlmodel/__init__.py` |
| 21 | `src/opinionated_mixins/contrib/mongoengine/__init__.py` |
| 22 | `src/opinionated_mixins/contrib/odmantic/__init__.py` |
| 23 | `src/opinionated_mixins/contrib/wtforms/__init__.py` |
| 24 | `src/opinionated_mixins/contrib/sqlalchemy/feedback.py` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `src/opinionated_mixins/contrib/sqlalchemy/feedback.py` | This file contains formatting changes (trailing comma adjustments) that are unrelated to the Template mixin feature being added |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->