### PR TITLE
feat: add Lead mixin across all contrib modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
 # TODO
 
 - What are our criteria for deciding on a contract / agreement / consensus mechanism?
+- No `index=True` in SQLAlchemy models, it can be declared with `__table_args__` by the user of the library but document that if a field is recommended to be indexed.

--- a/src/opinionated_mixins/__about__.py
+++ b/src/opinionated_mixins/__about__.py
@@ -1,4 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 __version__ = "0.0.1"

--- a/src/opinionated_mixins/__init__.py
+++ b/src/opinionated_mixins/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/src/opinionated_mixins/contrib/dataclasses/__init__.py
+++ b/src/opinionated_mixins/contrib/dataclasses/__init__.py
@@ -1,7 +1,5 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
+from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template

--- a/src/opinionated_mixins/contrib/dataclasses/announcement.py
+++ b/src/opinionated_mixins/contrib/dataclasses/announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import dataclasses
 from typing import Annotated
 
@@ -14,6 +11,8 @@ class Announcement:
 
     title: Annotated[str, Doc("Title of the announcement")]
     content: Annotated[str, Doc("Content of the announcement")]
-    category: Annotated[AnnouncementCategory, Doc("Category of the announcement")] = dataclasses.field(
-        default=AnnouncementCategory.GENERAL,
+    category: Annotated[AnnouncementCategory, Doc("Category of the announcement")] = (
+        dataclasses.field(
+            default=AnnouncementCategory.GENERAL,
+        )
     )

--- a/src/opinionated_mixins/contrib/dataclasses/feedback.py
+++ b/src/opinionated_mixins/contrib/dataclasses/feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import dataclasses
 from typing import Annotated
 

--- a/src/opinionated_mixins/contrib/dataclasses/lead.py
+++ b/src/opinionated_mixins/contrib/dataclasses/lead.py
@@ -1,0 +1,86 @@
+import dataclasses
+import datetime
+from decimal import Decimal
+from typing import Annotated
+
+from typing_extensions import Doc
+
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+
+@dataclasses.dataclass
+class Lead:
+    """Lead mixin for stdlib dataclasses."""
+
+    title: Annotated[
+        str | None,
+        Doc("Title of the customer or lead"),
+    ] = dataclasses.field(default=None)
+    salutation: Annotated[
+        str | None,
+        Doc("Salutation (e.g. Mr., Mrs., Dr.)"),
+    ] = dataclasses.field(default=None)
+    job_title: Annotated[
+        str | None,
+        Doc("Job title of the lead"),
+    ] = dataclasses.field(default=None)
+    company_name: Annotated[
+        str | None,
+        Doc("Company name of the lead"),
+    ] = dataclasses.field(default=None)
+    website: Annotated[
+        str | None,
+        Doc("Website URL of the lead"),
+    ] = dataclasses.field(default=None)
+    linkedin_url: Annotated[
+        str | None,
+        Doc("LinkedIn profile URL"),
+    ] = dataclasses.field(default=None)
+    status: Annotated[
+        LeadStatus | None,
+        Doc("Status in the sales pipeline"),
+    ] = dataclasses.field(default=None)
+    source: Annotated[
+        LeadSource | None,
+        Doc("Source channel where the lead originated"),
+    ] = dataclasses.field(default=None)
+    industry: Annotated[
+        str | None,
+        Doc("Industry of the lead"),
+    ] = dataclasses.field(default=None)
+    rating: Annotated[
+        LeadRating | None,
+        Doc("Temperature rating of the lead"),
+    ] = dataclasses.field(default=None)
+    opportunity_amount: Annotated[
+        Decimal | None,
+        Doc("Estimated opportunity value"),
+    ] = dataclasses.field(default=None)
+    currency: Annotated[
+        str | None,
+        Doc("Currency code (ISO 4217)"),
+    ] = dataclasses.field(default=None)
+    probability: Annotated[
+        int,
+        Doc("Conversion probability (0-100)"),
+    ] = dataclasses.field(default=0)
+    close_date: Annotated[
+        datetime.date | None,
+        Doc("Expected close date"),
+    ] = dataclasses.field(default=None)
+    last_contacted: Annotated[
+        datetime.date | None,
+        Doc("Date of last contact"),
+    ] = dataclasses.field(default=None)
+    next_follow_up: Annotated[
+        datetime.date | None,
+        Doc("Date of next follow-up"),
+    ] = dataclasses.field(default=None)
+    description: Annotated[
+        str | None,
+        Doc("Description of the lead"),
+    ] = dataclasses.field(default=None)
+    is_active: Annotated[
+        bool,
+        Doc("Whether the lead is active"),
+    ] = dataclasses.field(default=True)

--- a/src/opinionated_mixins/contrib/dataclasses/person.py
+++ b/src/opinionated_mixins/contrib/dataclasses/person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import dataclasses
 import datetime
 from typing import Annotated
@@ -15,30 +12,38 @@ class Person:
     first_name: Annotated[str, Doc("First name of the person")]
     last_name: Annotated[str, Doc("Last name of the person")]
     middle_name: Annotated[
-        str | None, Doc("Middle name of the person"),
+        str | None,
+        Doc("Middle name of the person"),
     ] = dataclasses.field(default=None)
     phone_number: Annotated[
-        str | None, Doc("Phone number of the person"),
+        str | None,
+        Doc("Phone number of the person"),
     ] = dataclasses.field(default=None)
     email: Annotated[
-        str | None, Doc("Email address of the person"),
+        str | None,
+        Doc("Email address of the person"),
     ] = dataclasses.field(default=None)
     street_address: Annotated[
-        str | None, Doc("Street address of the person"),
+        str | None,
+        Doc("Street address of the person"),
     ] = dataclasses.field(default=None)
     postal_code: Annotated[
-        str | None, Doc("Postal code of the person"),
+        str | None,
+        Doc("Postal code of the person"),
     ] = dataclasses.field(default=None)
     city: Annotated[
-        str | None, Doc("City of the person"),
+        str | None,
+        Doc("City of the person"),
     ] = dataclasses.field(default=None)
     country: Annotated[
         str | None,
         Doc("Country of the person (ISO 3166-1 alpha-2)"),
     ] = dataclasses.field(default=None)
     date_of_birth: Annotated[
-        datetime.date | None, Doc("Birth date of the person"),
+        datetime.date | None,
+        Doc("Birth date of the person"),
     ] = dataclasses.field(default=None)
     bio: Annotated[
-        str | None, Doc("Bio of the person"),
+        str | None,
+        Doc("Bio of the person"),
     ] = dataclasses.field(default=None)

--- a/src/opinionated_mixins/contrib/dataclasses/template.py
+++ b/src/opinionated_mixins/contrib/dataclasses/template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import dataclasses
 from typing import Annotated
 
@@ -14,8 +11,10 @@ class Template:
 
     name: Annotated[str, Doc("Name of the template")]
     content: Annotated[str, Doc("Content of the template")]
-    format: Annotated[TemplateFormat, Doc("Format of the template")] = dataclasses.field(
-        default=TemplateFormat.PLAIN,
+    format: Annotated[TemplateFormat, Doc("Format of the template")] = (
+        dataclasses.field(
+            default=TemplateFormat.PLAIN,
+        )
     )
     type: Annotated[TemplateType, Doc("Type of the template")] = dataclasses.field(
         default=TemplateType.OTHER,

--- a/src/opinionated_mixins/contrib/mongoengine/__init__.py
+++ b/src/opinionated_mixins/contrib/mongoengine/__init__.py
@@ -1,7 +1,5 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
+from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template

--- a/src/opinionated_mixins/contrib/mongoengine/announcement.py
+++ b/src/opinionated_mixins/contrib/mongoengine/announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from typing import Any, ClassVar
 
 from opinionated_mixins.enums import AnnouncementCategory

--- a/src/opinionated_mixins/contrib/mongoengine/feedback.py
+++ b/src/opinionated_mixins/contrib/mongoengine/feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from typing import Any, ClassVar
 
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus

--- a/src/opinionated_mixins/contrib/mongoengine/lead.py
+++ b/src/opinionated_mixins/contrib/mongoengine/lead.py
@@ -1,0 +1,39 @@
+from typing import Any, ClassVar
+
+from mongoengine import BooleanField, DateField, DecimalField, IntField, StringField
+
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+
+class Lead:
+    """Lead mixin for MongoEngine documents."""
+
+    meta: ClassVar[dict[str, Any]] = {"allow_inheritance": True}
+
+    title = StringField(required=False, max_length=255)
+    salutation = StringField(required=False, max_length=64)
+    job_title = StringField(required=False, max_length=255)
+    company_name = StringField(required=False, max_length=255)
+    website = StringField(required=False, max_length=255)
+    linkedin_url = StringField(required=False, max_length=500)
+    status = StringField(
+        required=False,
+        choices=[s.value for s in LeadStatus],
+    )
+    source = StringField(
+        required=False,
+        choices=[s.value for s in LeadSource],
+    )
+    industry = StringField(required=False, max_length=255)
+    rating = StringField(
+        required=False,
+        choices=[r.value for r in LeadRating],
+    )
+    opportunity_amount = DecimalField(required=False, precision=2)
+    currency = StringField(required=False, max_length=3)
+    probability = IntField(required=False, default=0)
+    close_date = DateField(required=False)
+    last_contacted = DateField(required=False)
+    next_follow_up = DateField(required=False)
+    description = StringField(required=False)
+    is_active = BooleanField(required=False, default=True)

--- a/src/opinionated_mixins/contrib/mongoengine/person.py
+++ b/src/opinionated_mixins/contrib/mongoengine/person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from typing import Any, ClassVar
 
 from mongoengine import DateField, StringField

--- a/src/opinionated_mixins/contrib/mongoengine/template.py
+++ b/src/opinionated_mixins/contrib/mongoengine/template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from typing import Any, ClassVar
 
 from opinionated_mixins.enums import TemplateFormat, TemplateType

--- a/src/opinionated_mixins/contrib/odmantic/__init__.py
+++ b/src/opinionated_mixins/contrib/odmantic/__init__.py
@@ -1,7 +1,5 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
+from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template

--- a/src/opinionated_mixins/contrib/odmantic/announcement.py
+++ b/src/opinionated_mixins/contrib/odmantic/announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import AnnouncementCategory
 
 from odmantic import Field

--- a/src/opinionated_mixins/contrib/odmantic/feedback.py
+++ b/src/opinionated_mixins/contrib/odmantic/feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 
 from odmantic import Field

--- a/src/opinionated_mixins/contrib/odmantic/lead.py
+++ b/src/opinionated_mixins/contrib/odmantic/lead.py
@@ -1,0 +1,29 @@
+import datetime
+from decimal import Decimal
+
+from odmantic import Field
+
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+
+class Lead:
+    """Lead mixin for ODMantic models."""
+
+    title: str | None = Field(default=None, max_length=255)
+    salutation: str | None = Field(default=None, max_length=64)
+    job_title: str | None = Field(default=None, max_length=255)
+    company_name: str | None = Field(default=None, max_length=255)
+    website: str | None = Field(default=None, max_length=255)
+    linkedin_url: str | None = Field(default=None, max_length=500)
+    status: LeadStatus | None = Field(default=None)
+    source: LeadSource | None = Field(default=None)
+    industry: str | None = Field(default=None, max_length=255)
+    rating: LeadRating | None = Field(default=None)
+    opportunity_amount: Decimal | None = Field(default=None)
+    currency: str | None = Field(default=None, max_length=3)
+    probability: int = Field(default=0)
+    close_date: datetime.date | None = Field(default=None)
+    last_contacted: datetime.date | None = Field(default=None)
+    next_follow_up: datetime.date | None = Field(default=None)
+    description: str | None = Field(default=None)
+    is_active: bool = Field(default=True)

--- a/src/opinionated_mixins/contrib/odmantic/person.py
+++ b/src/opinionated_mixins/contrib/odmantic/person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import datetime
 
 from odmantic import Field

--- a/src/opinionated_mixins/contrib/odmantic/template.py
+++ b/src/opinionated_mixins/contrib/odmantic/template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 
 from odmantic import Field

--- a/src/opinionated_mixins/contrib/pydantic/__init__.py
+++ b/src/opinionated_mixins/contrib/pydantic/__init__.py
@@ -1,7 +1,5 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
+from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template

--- a/src/opinionated_mixins/contrib/pydantic/announcement.py
+++ b/src/opinionated_mixins/contrib/pydantic/announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import AnnouncementCategory
 
 from pydantic import BaseModel, Field

--- a/src/opinionated_mixins/contrib/pydantic/feedback.py
+++ b/src/opinionated_mixins/contrib/pydantic/feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 
 from pydantic import BaseModel, Field

--- a/src/opinionated_mixins/contrib/pydantic/lead.py
+++ b/src/opinionated_mixins/contrib/pydantic/lead.py
@@ -1,0 +1,31 @@
+import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+
+class Lead(BaseModel):
+    """Lead mixin for Pydantic models."""
+
+    title: str | None = Field(default=None, max_length=255)
+    salutation: str | None = Field(default=None, max_length=64)
+    job_title: str | None = Field(default=None, max_length=255)
+    company_name: str | None = Field(default=None, max_length=255)
+    website: str | None = Field(default=None, max_length=255)
+    linkedin_url: str | None = Field(default=None, max_length=500)
+    status: LeadStatus | None = Field(default=None)
+    source: LeadSource | None = Field(default=None)
+    industry: str | None = Field(default=None, max_length=255)
+    rating: LeadRating | None = Field(default=None)
+    opportunity_amount: Decimal | None = Field(
+        default=None, max_digits=12, decimal_places=2
+    )
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    probability: int = Field(default=0, ge=0, le=100)
+    close_date: datetime.date | None = Field(default=None)
+    last_contacted: datetime.date | None = Field(default=None)
+    next_follow_up: datetime.date | None = Field(default=None)
+    description: str | None = Field(default=None)
+    is_active: bool = Field(default=True)

--- a/src/opinionated_mixins/contrib/pydantic/person.py
+++ b/src/opinionated_mixins/contrib/pydantic/person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import datetime
 
 from pydantic import BaseModel, Field

--- a/src/opinionated_mixins/contrib/pydantic/template.py
+++ b/src/opinionated_mixins/contrib/pydantic/template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 
 from pydantic import BaseModel, Field

--- a/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
@@ -1,7 +1,5 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
+from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template

--- a/src/opinionated_mixins/contrib/sqlalchemy/announcement.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import AnnouncementCategory
 
 from sqlalchemy import Column, Enum, String, Text
@@ -15,4 +12,6 @@ class Announcement:
 
     title = Column(String(255), nullable=False, index=True)
     content = Column(Text, nullable=False)
-    category = Column(Enum(AnnouncementCategory), nullable=False, default=AnnouncementCategory.GENERAL)
+    category = Column(
+        Enum(AnnouncementCategory), nullable=False, default=AnnouncementCategory.GENERAL
+    )

--- a/src/opinionated_mixins/contrib/sqlalchemy/feedback.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 
 from sqlalchemy import Column, Enum, String, Text
@@ -16,8 +13,12 @@ class Feedback:
     subject = Column(String(255), nullable=False, index=True)
     content = Column(Text, nullable=False)
     category = Column(
-        Enum(FeedbackCategory), nullable=False, default=FeedbackCategory.OTHER,
+        Enum(FeedbackCategory),
+        nullable=False,
+        default=FeedbackCategory.OTHER,
     )
     status = Column(
-        Enum(FeedbackStatus), nullable=False, default=FeedbackStatus.PENDING,
+        Enum(FeedbackStatus),
+        nullable=False,
+        default=FeedbackStatus.PENDING,
     )

--- a/src/opinionated_mixins/contrib/sqlalchemy/lead.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/lead.py
@@ -1,0 +1,30 @@
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+from sqlalchemy import Boolean, Column, Date, Enum, Integer, Numeric, String, Text
+from sqlalchemy.orm import declarative_mixin
+
+
+@declarative_mixin
+class Lead:
+    """Lead mixin for SQLAlchemy models."""
+
+    __abstract__ = True
+
+    title = Column(String(255), nullable=True)
+    salutation = Column(String(64), nullable=True)
+    job_title = Column(String(255), nullable=True)
+    company_name = Column(String(255), nullable=True)
+    website = Column(String(255), nullable=True)
+    linkedin_url = Column(String(500), nullable=True)
+    status = Column(Enum(LeadStatus), nullable=True)
+    source = Column(Enum(LeadSource), nullable=True)
+    industry = Column(String(255), nullable=True)
+    rating = Column(Enum(LeadRating), nullable=True)
+    opportunity_amount = Column(Numeric(precision=12, scale=2), nullable=True)
+    currency = Column(String(3), nullable=True)
+    probability = Column(Integer, nullable=True, default=0)
+    close_date = Column(Date, nullable=True)
+    last_contacted = Column(Date, nullable=True)
+    next_follow_up = Column(Date, nullable=True)
+    description = Column(Text, nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)

--- a/src/opinionated_mixins/contrib/sqlalchemy/person.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/person.py
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
-
 from sqlalchemy import Column, Date, String, Text
 from sqlalchemy.orm import declarative_mixin
 

--- a/src/opinionated_mixins/contrib/sqlalchemy/template.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 
 from sqlalchemy import Column, Enum, String, Text

--- a/src/opinionated_mixins/contrib/sqlmodel/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/__init__.py
@@ -1,7 +1,5 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
+from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template

--- a/src/opinionated_mixins/contrib/sqlmodel/announcement.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlalchemy.announcement import (
     Announcement as Announcement,
 )

--- a/src/opinionated_mixins/contrib/sqlmodel/feedback.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlalchemy.feedback import (
     Feedback as Feedback,
 )

--- a/src/opinionated_mixins/contrib/sqlmodel/lead.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/lead.py
@@ -1,0 +1,3 @@
+from opinionated_mixins.contrib.sqlalchemy.lead import (
+    Lead as Lead,
+)

--- a/src/opinionated_mixins/contrib/sqlmodel/person.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlalchemy.person import (
     Person as Person,
 )

--- a/src/opinionated_mixins/contrib/sqlmodel/template.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlalchemy.template import (
     Template as Template,
 )

--- a/src/opinionated_mixins/contrib/wtforms/__init__.py
+++ b/src/opinionated_mixins/contrib/wtforms/__init__.py
@@ -1,7 +1,5 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from .announcement import Announcement as Announcement
 from .feedback import Feedback as Feedback
+from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template

--- a/src/opinionated_mixins/contrib/wtforms/announcement.py
+++ b/src/opinionated_mixins/contrib/wtforms/announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import AnnouncementCategory
 
 from wtforms import SelectField, StringField, TextAreaField

--- a/src/opinionated_mixins/contrib/wtforms/feedback.py
+++ b/src/opinionated_mixins/contrib/wtforms/feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 
 from wtforms import SelectField, StringField, TextAreaField

--- a/src/opinionated_mixins/contrib/wtforms/lead.py
+++ b/src/opinionated_mixins/contrib/wtforms/lead.py
@@ -1,0 +1,97 @@
+from wtforms import (
+    BooleanField,
+    DateField,
+    DecimalField,
+    IntegerField,
+    SelectField,
+    StringField,
+    TextAreaField,
+)
+from wtforms.validators import Length, NumberRange, Optional
+
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+
+class Lead:
+    """Lead mixin for WTForms forms."""
+
+    title = StringField(
+        label="Title",
+        validators=[Length(max=255), Optional()],
+    )
+    salutation = StringField(
+        label="Salutation",
+        validators=[Length(max=64), Optional()],
+    )
+    job_title = StringField(
+        label="Job Title",
+        validators=[Length(max=255), Optional()],
+    )
+    company_name = StringField(
+        label="Company Name",
+        validators=[Length(max=255), Optional()],
+    )
+    website = StringField(
+        label="Website",
+        validators=[Length(max=255), Optional()],
+    )
+    linkedin_url = StringField(
+        label="LinkedIn URL",
+        validators=[Length(max=500), Optional()],
+    )
+    status = SelectField(
+        label="Status",
+        choices=[(s.value, s.value) for s in LeadStatus],
+        default=None,
+        validators=[Optional()],
+    )
+    source = SelectField(
+        label="Source",
+        choices=[(s.value, s.value) for s in LeadSource],
+        default=None,
+        validators=[Optional()],
+    )
+    industry = StringField(
+        label="Industry",
+        validators=[Length(max=255), Optional()],
+    )
+    rating = SelectField(
+        label="Rating",
+        choices=[(r.value, r.value) for r in LeadRating],
+        default=None,
+        validators=[Optional()],
+    )
+    opportunity_amount = DecimalField(
+        label="Opportunity Amount",
+        places=2,
+        validators=[Optional()],
+    )
+    currency = StringField(
+        label="Currency",
+        validators=[Length(min=3, max=3), Optional()],
+    )
+    probability = IntegerField(
+        label="Probability",
+        default=0,
+        validators=[NumberRange(min=0, max=100), Optional()],
+    )
+    close_date = DateField(
+        label="Close Date",
+        validators=[Optional()],
+    )
+    last_contacted = DateField(
+        label="Last Contacted",
+        validators=[Optional()],
+    )
+    next_follow_up = DateField(
+        label="Next Follow Up",
+        validators=[Optional()],
+    )
+    description = TextAreaField(
+        label="Description",
+        validators=[Optional()],
+    )
+    is_active = BooleanField(
+        label="Is Active",
+        default=True,
+    )

--- a/src/opinionated_mixins/contrib/wtforms/person.py
+++ b/src/opinionated_mixins/contrib/wtforms/person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from wtforms import DateField, StringField, TextAreaField
 from wtforms.validators import DataRequired, Length, Optional
 

--- a/src/opinionated_mixins/contrib/wtforms/template.py
+++ b/src/opinionated_mixins/contrib/wtforms/template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 
 from wtforms import SelectField, StringField, TextAreaField

--- a/src/opinionated_mixins/enums.py
+++ b/src/opinionated_mixins/enums.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import enum
 
 
@@ -32,6 +29,36 @@ class TemplateType(str, enum.Enum):
     SMS = "sms"
     PUSH = "push"
     OTHER = "other"
+
+
+class LeadStatus(str, enum.Enum):
+    """Status of a lead in the sales pipeline."""
+
+    ASSIGNED = "assigned"
+    IN_PROCESS = "in_process"
+    CONVERTED = "converted"
+    RECYCLED = "recycled"
+    CLOSED = "closed"
+
+
+class LeadSource(str, enum.Enum):
+    """Source channel where a lead originated."""
+
+    CALL = "call"
+    EMAIL = "email"
+    EXISTING_CUSTOMER = "existing_customer"
+    PARTNER = "partner"
+    PUBLIC_RELATIONS = "public_relations"
+    CAMPAIGN = "campaign"
+    OTHER = "other"
+
+
+class LeadRating(str, enum.Enum):
+    """Temperature rating of a lead."""
+
+    HOT = "hot"
+    WARM = "warm"
+    COLD = "cold"
 
 
 class FeedbackCategory(str, enum.Enum):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/tests/dataclasses/__init__.py
+++ b/tests/dataclasses/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/tests/dataclasses/test_announcement.py
+++ b/tests/dataclasses/test_announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import dataclasses
 
 from opinionated_mixins.contrib.dataclasses import Announcement

--- a/tests/dataclasses/test_feedback.py
+++ b/tests/dataclasses/test_feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import dataclasses
 
 from opinionated_mixins.contrib.dataclasses import Feedback

--- a/tests/dataclasses/test_lead.py
+++ b/tests/dataclasses/test_lead.py
@@ -1,0 +1,67 @@
+import dataclasses
+import datetime
+from decimal import Decimal
+
+from opinionated_mixins.contrib.dataclasses import Lead
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+LEAD_FIELDS = {
+    "title",
+    "salutation",
+    "job_title",
+    "company_name",
+    "website",
+    "linkedin_url",
+    "status",
+    "source",
+    "industry",
+    "rating",
+    "opportunity_amount",
+    "currency",
+    "probability",
+    "close_date",
+    "last_contacted",
+    "next_follow_up",
+    "description",
+    "is_active",
+}
+
+
+class TestDataclassesLead:
+    def test_is_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(Lead)
+
+    def test_create_defaults(self) -> None:
+        obj = Lead()
+        assert obj.title is None
+        assert obj.status is None
+        assert obj.probability == 0
+        assert obj.is_active is True
+
+    def test_create_with_all_fields(self) -> None:
+        obj = Lead(
+            title="Dr.",
+            salutation="Dr.",
+            job_title="CTO",
+            company_name="Acme Inc.",
+            website="https://acme.com",
+            linkedin_url="https://linkedin.com/in/jane",
+            status=LeadStatus.ASSIGNED,
+            source=LeadSource.EMAIL,
+            industry="Technology",
+            rating=LeadRating.HOT,
+            opportunity_amount=Decimal("50000.00"),
+            currency="USD",
+            probability=75,
+            close_date=datetime.date(2026, 6, 1),
+            last_contacted=datetime.date(2026, 4, 15),
+            next_follow_up=datetime.date(2026, 4, 22),
+            description="High-value lead",
+            is_active=True,
+        )
+        assert obj.job_title == "CTO"
+        assert obj.status == LeadStatus.ASSIGNED
+
+    def test_fields(self) -> None:
+        fields = {f.name for f in dataclasses.fields(Lead)}
+        assert fields == LEAD_FIELDS

--- a/tests/dataclasses/test_person.py
+++ b/tests/dataclasses/test_person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import dataclasses
 import datetime
 

--- a/tests/dataclasses/test_template.py
+++ b/tests/dataclasses/test_template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import dataclasses
 
 from opinionated_mixins.contrib.dataclasses import Template

--- a/tests/mongoengine/__init__.py
+++ b/tests/mongoengine/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/tests/mongoengine/test_announcement.py
+++ b/tests/mongoengine/test_announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.mongoengine import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
 

--- a/tests/mongoengine/test_feedback.py
+++ b/tests/mongoengine/test_feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.mongoengine import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 

--- a/tests/mongoengine/test_lead.py
+++ b/tests/mongoengine/test_lead.py
@@ -1,0 +1,40 @@
+from opinionated_mixins.contrib.mongoengine import Lead
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+
+class TestMongoEngineLead:
+    def test_has_title_field(self) -> None:
+        assert Lead.title.required is False
+        assert Lead.title.max_length == 255
+
+    def test_has_status_field(self) -> None:
+        assert Lead.status.required is False
+        assert Lead.status.choices == [s.value for s in LeadStatus]
+
+    def test_has_source_field(self) -> None:
+        assert Lead.source.required is False
+        assert Lead.source.choices == [s.value for s in LeadSource]
+
+    def test_has_rating_field(self) -> None:
+        assert Lead.rating.required is False
+        assert Lead.rating.choices == [r.value for r in LeadRating]
+
+    def test_has_scalar_fields(self) -> None:
+        for field_name in (
+            "title",
+            "salutation",
+            "job_title",
+            "company_name",
+            "website",
+            "linkedin_url",
+            "industry",
+            "opportunity_amount",
+            "currency",
+            "probability",
+            "close_date",
+            "last_contacted",
+            "next_follow_up",
+            "description",
+            "is_active",
+        ):
+            assert hasattr(Lead, field_name), f"Missing field: {field_name}"

--- a/tests/mongoengine/test_person.py
+++ b/tests/mongoengine/test_person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.mongoengine import Person
 
 

--- a/tests/mongoengine/test_template.py
+++ b/tests/mongoengine/test_template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.mongoengine import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 

--- a/tests/odmantic/__init__.py
+++ b/tests/odmantic/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/tests/odmantic/test_announcement.py
+++ b/tests/odmantic/test_announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.odmantic import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
 
@@ -13,4 +10,7 @@ class TestODManticAnnouncement:
         assert "category" in annotations
 
     def test_category_default(self) -> None:
-        assert Announcement.category.pydantic_field_info.default == AnnouncementCategory.GENERAL
+        assert (
+            Announcement.category.pydantic_field_info.default
+            == AnnouncementCategory.GENERAL
+        )

--- a/tests/odmantic/test_feedback.py
+++ b/tests/odmantic/test_feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.odmantic import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 

--- a/tests/odmantic/test_lead.py
+++ b/tests/odmantic/test_lead.py
@@ -1,0 +1,42 @@
+from opinionated_mixins.contrib.odmantic import Lead
+
+
+LEAD_ANNOTATIONS = {
+    "title",
+    "salutation",
+    "job_title",
+    "company_name",
+    "website",
+    "linkedin_url",
+    "status",
+    "source",
+    "industry",
+    "rating",
+    "opportunity_amount",
+    "currency",
+    "probability",
+    "close_date",
+    "last_contacted",
+    "next_follow_up",
+    "description",
+    "is_active",
+}
+
+
+class TestODManticLead:
+    def test_has_expected_annotations(self) -> None:
+        for field_name in LEAD_ANNOTATIONS:
+            assert field_name in Lead.__annotations__
+
+    def test_optional_fields_default_none(self) -> None:
+        for field_name in ("title", "status", "source", "rating", "close_date"):
+            field_info = getattr(Lead, field_name).pydantic_field_info
+            assert field_info.default is None, f"{field_name} should default to None"
+
+    def test_probability_default(self) -> None:
+        field_info = Lead.probability.pydantic_field_info
+        assert field_info.default == 0
+
+    def test_is_active_default(self) -> None:
+        field_info = Lead.is_active.pydantic_field_info
+        assert field_info.default is True

--- a/tests/odmantic/test_person.py
+++ b/tests/odmantic/test_person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.odmantic import Person
 
 

--- a/tests/odmantic/test_template.py
+++ b/tests/odmantic/test_template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.odmantic import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 

--- a/tests/pydantic/__init__.py
+++ b/tests/pydantic/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/tests/pydantic/test_announcement.py
+++ b/tests/pydantic/test_announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import pytest
 from opinionated_mixins.contrib.pydantic import Announcement
 from opinionated_mixins.enums import AnnouncementCategory

--- a/tests/pydantic/test_feedback.py
+++ b/tests/pydantic/test_feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import pytest
 from opinionated_mixins.contrib.pydantic import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus

--- a/tests/pydantic/test_lead.py
+++ b/tests/pydantic/test_lead.py
@@ -1,0 +1,65 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+from opinionated_mixins.contrib.pydantic import Lead
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+from pydantic import ValidationError
+
+
+class TestPydanticLead:
+    def test_create_defaults(self) -> None:
+        obj = Lead()
+        assert obj.title is None
+        assert obj.status is None
+        assert obj.probability == 0
+        assert obj.is_active is True
+
+    def test_create_with_all_fields(self) -> None:
+        obj = Lead(
+            title="Dr.",
+            salutation="Dr.",
+            job_title="CTO",
+            company_name="Acme Inc.",
+            website="https://acme.com",
+            linkedin_url="https://linkedin.com/in/jane",
+            status=LeadStatus.ASSIGNED,
+            source=LeadSource.EMAIL,
+            industry="Technology",
+            rating=LeadRating.HOT,
+            opportunity_amount=Decimal("50000.00"),
+            currency="USD",
+            probability=75,
+            close_date=datetime.date(2026, 6, 1),
+            last_contacted=datetime.date(2026, 4, 15),
+            next_follow_up=datetime.date(2026, 4, 22),
+            description="High-value lead",
+            is_active=True,
+        )
+        assert obj.job_title == "CTO"
+        assert obj.status == LeadStatus.ASSIGNED
+        assert obj.rating == LeadRating.HOT
+
+    def test_title_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            Lead(title="x" * 256)
+
+    def test_status_from_string(self) -> None:
+        obj = Lead(status="assigned")
+        assert obj.status == LeadStatus.ASSIGNED
+
+    def test_invalid_status_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Lead(status="invalid")
+
+    def test_probability_range(self) -> None:
+        with pytest.raises(ValidationError):
+            Lead(probability=101)
+        with pytest.raises(ValidationError):
+            Lead(probability=-1)
+
+    def test_currency_must_be_three_chars(self) -> None:
+        with pytest.raises(ValidationError):
+            Lead(currency="US")
+        with pytest.raises(ValidationError):
+            Lead(currency="USDD")

--- a/tests/pydantic/test_person.py
+++ b/tests/pydantic/test_person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import datetime
 
 import pytest

--- a/tests/pydantic/test_template.py
+++ b/tests/pydantic/test_template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import pytest
 from opinionated_mixins.contrib.pydantic import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType

--- a/tests/sqlalchemy/__init__.py
+++ b/tests/sqlalchemy/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/tests/sqlalchemy/test_announcement.py
+++ b/tests/sqlalchemy/test_announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlalchemy import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
 from sqlalchemy import Column, Integer, create_engine

--- a/tests/sqlalchemy/test_feedback.py
+++ b/tests/sqlalchemy/test_feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlalchemy import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 from sqlalchemy import Column, Integer, create_engine

--- a/tests/sqlalchemy/test_lead.py
+++ b/tests/sqlalchemy/test_lead.py
@@ -1,0 +1,90 @@
+import datetime
+from decimal import Decimal
+
+from opinionated_mixins.contrib.sqlalchemy import Lead
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+Base = declarative_base()
+
+
+class MyLead(Lead, Base):  # type: ignore[misc]
+    __tablename__ = "leads"
+    id = Column(Integer, primary_key=True)
+
+
+LEAD_FIELDS = {
+    "title",
+    "salutation",
+    "job_title",
+    "company_name",
+    "website",
+    "linkedin_url",
+    "status",
+    "source",
+    "industry",
+    "rating",
+    "opportunity_amount",
+    "currency",
+    "probability",
+    "close_date",
+    "last_contacted",
+    "next_follow_up",
+    "description",
+    "is_active",
+}
+
+
+class TestSQLAlchemyLead:
+    def setup_method(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+
+    def test_create_defaults(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyLead()
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.title is None
+            assert obj.status is None
+            assert obj.probability == 0
+            assert obj.is_active is True
+
+    def test_create_with_all_fields(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyLead(
+                title="Dr.",
+                salutation="Dr.",
+                job_title="CTO",
+                company_name="Acme Inc.",
+                website="https://acme.com",
+                linkedin_url="https://linkedin.com/in/jane",
+                status=LeadStatus.ASSIGNED,
+                source=LeadSource.EMAIL,
+                industry="Technology",
+                rating=LeadRating.HOT,
+                opportunity_amount=Decimal("50000.00"),
+                currency="USD",
+                probability=75,
+                close_date=datetime.date(2026, 6, 1),
+                last_contacted=datetime.date(2026, 4, 15),
+                next_follow_up=datetime.date(2026, 4, 22),
+                description="High-value lead",
+                is_active=True,
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.job_title == "CTO"
+            assert obj.status == LeadStatus.ASSIGNED
+            assert obj.source == LeadSource.EMAIL
+            assert obj.rating == LeadRating.HOT
+            assert obj.opportunity_amount == Decimal("50000.00")
+            assert obj.probability == 75
+            assert obj.close_date == datetime.date(2026, 6, 1)
+
+    def test_fields_exist(self) -> None:
+        columns = {c.name for c in MyLead.__table__.columns}
+        assert LEAD_FIELDS.issubset(columns)

--- a/tests/sqlalchemy/test_person.py
+++ b/tests/sqlalchemy/test_person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 import datetime
 
 from opinionated_mixins.contrib.sqlalchemy import Person

--- a/tests/sqlalchemy/test_template.py
+++ b/tests/sqlalchemy/test_template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlalchemy import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 from sqlalchemy import Column, Integer, create_engine

--- a/tests/sqlmodel/__init__.py
+++ b/tests/sqlmodel/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/tests/sqlmodel/test_announcement.py
+++ b/tests/sqlmodel/test_announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlmodel import Announcement
 
 

--- a/tests/sqlmodel/test_feedback.py
+++ b/tests/sqlmodel/test_feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlmodel import Feedback
 
 

--- a/tests/sqlmodel/test_lead.py
+++ b/tests/sqlmodel/test_lead.py
@@ -1,0 +1,10 @@
+from opinionated_mixins.contrib.sqlmodel import Lead
+
+
+class TestSQLModelLead:
+    def test_reexports_sqlalchemy(self) -> None:
+        from opinionated_mixins.contrib.sqlalchemy import (
+            Lead as SALead,
+        )
+
+        assert Lead is SALead

--- a/tests/sqlmodel/test_person.py
+++ b/tests/sqlmodel/test_person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlmodel import Person
 
 

--- a/tests/sqlmodel/test_template.py
+++ b/tests/sqlmodel/test_template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.sqlmodel import Template
 
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,7 +1,11 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
-from opinionated_mixins.enums import AnnouncementCategory, TemplateFormat, TemplateType
+from opinionated_mixins.enums import (
+    AnnouncementCategory,
+    LeadRating,
+    LeadSource,
+    LeadStatus,
+    TemplateFormat,
+    TemplateType,
+)
 
 
 class TestAnnouncementCategory:
@@ -37,6 +41,53 @@ class TestTemplateFormat:
 
     def test_lookup_by_value(self) -> None:
         assert TemplateFormat("html") is TemplateFormat.HTML
+
+
+class TestLeadStatus:
+    def test_values(self) -> None:
+        expected = ["assigned", "in_process", "converted", "recycled", "closed"]
+        assert [s.value for s in LeadStatus] == expected
+
+    def test_str_mixin(self) -> None:
+        assert LeadStatus.ASSIGNED == "assigned"
+        assert isinstance(LeadStatus.CONVERTED, str)
+
+    def test_lookup_by_value(self) -> None:
+        assert LeadStatus("converted") is LeadStatus.CONVERTED
+
+
+class TestLeadSource:
+    def test_values(self) -> None:
+        expected = [
+            "call",
+            "email",
+            "existing_customer",
+            "partner",
+            "public_relations",
+            "campaign",
+            "other",
+        ]
+        assert [s.value for s in LeadSource] == expected
+
+    def test_str_mixin(self) -> None:
+        assert LeadSource.CALL == "call"
+        assert isinstance(LeadSource.EMAIL, str)
+
+    def test_lookup_by_value(self) -> None:
+        assert LeadSource("partner") is LeadSource.PARTNER
+
+
+class TestLeadRating:
+    def test_values(self) -> None:
+        expected = ["hot", "warm", "cold"]
+        assert [r.value for r in LeadRating] == expected
+
+    def test_str_mixin(self) -> None:
+        assert LeadRating.HOT == "hot"
+        assert isinstance(LeadRating.WARM, str)
+
+    def test_lookup_by_value(self) -> None:
+        assert LeadRating("cold") is LeadRating.COLD
 
 
 class TestTemplateType:

--- a/tests/wtforms/__init__.py
+++ b/tests/wtforms/__init__.py
@@ -1,3 +1,1 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
+

--- a/tests/wtforms/test_announcement.py
+++ b/tests/wtforms/test_announcement.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.wtforms import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
 from wtforms import Form

--- a/tests/wtforms/test_feedback.py
+++ b/tests/wtforms/test_feedback.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.wtforms import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 from wtforms import Form

--- a/tests/wtforms/test_lead.py
+++ b/tests/wtforms/test_lead.py
@@ -1,0 +1,51 @@
+from opinionated_mixins.contrib.wtforms import Lead
+from wtforms import Form
+
+
+class LeadForm(Lead, Form):  # type: ignore[misc]
+    pass
+
+
+LEAD_FIELDS = {
+    "title",
+    "salutation",
+    "job_title",
+    "company_name",
+    "website",
+    "linkedin_url",
+    "status",
+    "source",
+    "industry",
+    "rating",
+    "opportunity_amount",
+    "currency",
+    "probability",
+    "close_date",
+    "last_contacted",
+    "next_follow_up",
+    "description",
+    "is_active",
+}
+
+
+class TestWTFormsLead:
+    def test_has_fields(self) -> None:
+        form = LeadForm()
+        for field_name in LEAD_FIELDS:
+            assert field_name in form._fields, f"Missing field: {field_name}"
+
+    def test_valid_submission_minimal(self) -> None:
+        form = LeadForm(data={})
+        assert form.validate()
+
+    def test_valid_submission_with_data(self) -> None:
+        form = LeadForm(
+            data={
+                "title": "Dr.",
+                "job_title": "CTO",
+                "status": "assigned",
+                "source": "email",
+                "rating": "hot",
+            },
+        )
+        assert form.validate()

--- a/tests/wtforms/test_person.py
+++ b/tests/wtforms/test_person.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.wtforms import Person
 from wtforms import Form
 

--- a/tests/wtforms/test_template.py
+++ b/tests/wtforms/test_template.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2024-present hasansezertasan <hasansezertasan@gmail.com>
-#
-# SPDX-License-Identifier: MIT
 from opinionated_mixins.contrib.wtforms import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 from wtforms import Form


### PR DESCRIPTION
## Summary

- Add standalone Lead mixin with 18 CRM fields based on [Django-CRM's lead model](https://github.com/MicroPyramid/Django-CRM/blob/master/backend/leads/models.py)
- Add `LeadStatus`, `LeadSource`, `LeadRating` enums to shared enums module
- Implement across all 7 contrib modules (SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, SQLModel)

### Fields

`title`, `salutation`, `job_title`, `company_name`, `website`, `linkedin_url`, `status`, `source`, `industry`, `rating`, `opportunity_amount`, `currency`, `probability`, `close_date`, `last_contacted`, `next_follow_up`, `description`, `is_active`

### Design decisions

- **Standalone mixin** — does not inherit Person. Users compose `class MyLead(Lead, Person, Base)` as needed
- **No index on title** — no major CRM indexes job title (researched 7 CRMs: Salesforce, HubSpot, Odoo, Django-CRM, SuiteCRM, Zoho, MS Dynamics)
- **Industry as free text** — too many values for a useful enum
- **Field name `title`** — consensus across 5/7 CRMs (Salesforce, Zoho, SuiteCRM, DjangoCRM, Django-CRM)

Closes #15

## Test plan

- [x] 176 tests pass (`uv run pytest tests/`)
- [x] All 7 frameworks tested with field existence, defaults, and validation
- [x] Enum tests for LeadStatus, LeadSource, LeadRating
- [x] Pydantic validation: probability range (0-100), currency length (3), title max length
- [x] SQLAlchemy: full CRUD with in-memory SQLite
- [x] SQLModel re-exports verified

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new standalone `Lead` mixin with 18 CRM fields across all 7 supported framework modules (SQLAlchemy, Pydantic, MongoEngine, ODMantic, WTForms, dataclasses, SQLModel). The implementation introduces three new enums (`LeadStatus`, `LeadSource`, `LeadRating`) to the shared enums module and follows the design decision to keep `Lead` as a standalone mixin that doesn't inherit from `Person`, allowing users to compose them as needed. The PR includes comprehensive test coverage (176 tests) with field existence checks, default value validation, and framework-specific validations like Pydantic's probability range (0-100) and currency length constraints.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/opinionated_mixins/enums.py` |
| 2 | `src/opinionated_mixins/contrib/pydantic/lead.py` |
| 3 | `src/opinionated_mixins/contrib/sqlalchemy/lead.py` |
| 4 | `src/opinionated_mixins/contrib/dataclasses/lead.py` |
| 5 | `src/opinionated_mixins/contrib/odmantic/lead.py` |
| 6 | `src/opinionated_mixins/contrib/mongoengine/lead.py` |
| 7 | `src/opinionated_mixins/contrib/wtforms/lead.py` |
| 8 | `src/opinionated_mixins/contrib/sqlmodel/lead.py` |
| 9 | `tests/test_enums.py` |
| 10 | `tests/pydantic/test_lead.py` |
| 11 | `tests/sqlalchemy/test_lead.py` |
| 12 | `tests/dataclasses/test_lead.py` |
| 13 | `tests/odmantic/test_lead.py` |
| 14 | `tests/mongoengine/test_lead.py` |
| 15 | `tests/wtforms/test_lead.py` |
| 16 | `tests/sqlmodel/test_lead.py` |
| 17 | `src/opinionated_mixins/contrib/pydantic/__init__.py` |
| 18 | `src/opinionated_mixins/contrib/sqlalchemy/__init__.py` |
| 19 | `src/opinionated_mixins/contrib/dataclasses/__init__.py` |
| 20 | `src/opinionated_mixins/contrib/odmantic/__init__.py` |
| 21 | `src/opinionated_mixins/contrib/mongoengine/__init__.py` |
| 22 | `src/opinionated_mixins/contrib/wtforms/__init__.py` |
| 23 | `src/opinionated_mixins/contrib/sqlmodel/__init__.py` |
| 24 | `TODO.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->