### PR TITLE
feat: add User mixin across all contrib modules

### DIFF
--- a/src/opinionated_mixins/contrib/dataclasses/__init__.py
+++ b/src/opinionated_mixins/contrib/dataclasses/__init__.py
@@ -3,3 +3,4 @@ from .feedback import Feedback as Feedback
 from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template
+from .user import User as User

--- a/src/opinionated_mixins/contrib/dataclasses/lead.py
+++ b/src/opinionated_mixins/contrib/dataclasses/lead.py
@@ -3,9 +3,8 @@ import datetime
 from decimal import Decimal
 from typing import Annotated
 
-from typing_extensions import Doc
-
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+from typing_extensions import Doc
 
 
 @dataclasses.dataclass

--- a/src/opinionated_mixins/contrib/dataclasses/user.py
+++ b/src/opinionated_mixins/contrib/dataclasses/user.py
@@ -1,0 +1,21 @@
+import dataclasses
+import datetime
+from typing import Annotated
+
+from typing_extensions import Doc
+
+
+@dataclasses.dataclass
+class User:
+    """User mixin for stdlib dataclasses."""
+
+    username: Annotated[str, Doc("Unique username")]
+    hashed_password: Annotated[str, Doc("Hashed password")]
+    email: Annotated[
+        str | None,
+        Doc("Email address of the user"),
+    ] = dataclasses.field(default=None)
+    date_email_verified: Annotated[
+        datetime.datetime | None,
+        Doc("Date when email was verified"),
+    ] = dataclasses.field(default=None)

--- a/src/opinionated_mixins/contrib/mongoengine/__init__.py
+++ b/src/opinionated_mixins/contrib/mongoengine/__init__.py
@@ -3,3 +3,4 @@ from .feedback import Feedback as Feedback
 from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template
+from .user import User as User

--- a/src/opinionated_mixins/contrib/mongoengine/lead.py
+++ b/src/opinionated_mixins/contrib/mongoengine/lead.py
@@ -1,8 +1,8 @@
 from typing import Any, ClassVar
 
-from mongoengine import BooleanField, DateField, DecimalField, IntField, StringField
-
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+from mongoengine import BooleanField, DateField, DecimalField, IntField, StringField
 
 
 class Lead:

--- a/src/opinionated_mixins/contrib/mongoengine/user.py
+++ b/src/opinionated_mixins/contrib/mongoengine/user.py
@@ -1,0 +1,14 @@
+from typing import Any, ClassVar
+
+from mongoengine import DateTimeField, StringField
+
+
+class User:
+    """User mixin for MongoEngine documents."""
+
+    meta: ClassVar[dict[str, Any]] = {"allow_inheritance": True}
+
+    username = StringField(required=True, max_length=255, unique=True)
+    hashed_password = StringField(required=True, max_length=1024)
+    email = StringField(required=False, max_length=254, unique=True, sparse=True)
+    date_email_verified = DateTimeField(required=False)

--- a/src/opinionated_mixins/contrib/odmantic/__init__.py
+++ b/src/opinionated_mixins/contrib/odmantic/__init__.py
@@ -3,3 +3,4 @@ from .feedback import Feedback as Feedback
 from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template
+from .user import User as User

--- a/src/opinionated_mixins/contrib/odmantic/lead.py
+++ b/src/opinionated_mixins/contrib/odmantic/lead.py
@@ -1,9 +1,9 @@
 import datetime
 from decimal import Decimal
 
-from odmantic import Field
-
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+from odmantic import Field
 
 
 class Lead:

--- a/src/opinionated_mixins/contrib/odmantic/user.py
+++ b/src/opinionated_mixins/contrib/odmantic/user.py
@@ -1,0 +1,12 @@
+import datetime
+
+from odmantic import Field
+
+
+class User:
+    """User mixin for ODMantic models."""
+
+    username: str = Field(..., min_length=1, max_length=255)
+    hashed_password: str = Field(..., min_length=1)
+    email: str | None = Field(default=None, max_length=254)
+    date_email_verified: datetime.datetime | None = Field(default=None)

--- a/src/opinionated_mixins/contrib/pydantic/__init__.py
+++ b/src/opinionated_mixins/contrib/pydantic/__init__.py
@@ -3,3 +3,4 @@ from .feedback import Feedback as Feedback
 from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template
+from .user import User as User

--- a/src/opinionated_mixins/contrib/pydantic/lead.py
+++ b/src/opinionated_mixins/contrib/pydantic/lead.py
@@ -1,9 +1,9 @@
 import datetime
 from decimal import Decimal
 
-from pydantic import BaseModel, Field
-
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+from pydantic import BaseModel, Field
 
 
 class Lead(BaseModel):
@@ -20,7 +20,7 @@ class Lead(BaseModel):
     industry: str | None = Field(default=None, max_length=255)
     rating: LeadRating | None = Field(default=None)
     opportunity_amount: Decimal | None = Field(
-        default=None, max_digits=12, decimal_places=2
+        default=None, max_digits=12, decimal_places=2,
     )
     currency: str | None = Field(default=None, min_length=3, max_length=3)
     probability: int = Field(default=0, ge=0, le=100)

--- a/src/opinionated_mixins/contrib/pydantic/user.py
+++ b/src/opinionated_mixins/contrib/pydantic/user.py
@@ -1,0 +1,12 @@
+import datetime
+
+from pydantic import BaseModel, Field
+
+
+class User(BaseModel):
+    """User mixin for Pydantic models."""
+
+    username: str = Field(..., min_length=1, max_length=255)
+    hashed_password: str = Field(..., min_length=1)
+    email: str | None = Field(default=None, max_length=254)
+    date_email_verified: datetime.datetime | None = Field(default=None)

--- a/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
@@ -3,3 +3,4 @@ from .feedback import Feedback as Feedback
 from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template
+from .user import User as User

--- a/src/opinionated_mixins/contrib/sqlalchemy/announcement.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/announcement.py
@@ -13,5 +13,5 @@ class Announcement:
     title = Column(String(255), nullable=False, index=True)
     content = Column(Text, nullable=False)
     category = Column(
-        Enum(AnnouncementCategory), nullable=False, default=AnnouncementCategory.GENERAL
+        Enum(AnnouncementCategory), nullable=False, default=AnnouncementCategory.GENERAL,
     )

--- a/src/opinionated_mixins/contrib/sqlalchemy/user.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/user.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, DateTime, String
+from sqlalchemy.orm import declarative_mixin
+
+
+@declarative_mixin
+class User:
+    """User mixin for SQLAlchemy models."""
+
+    __abstract__ = True
+
+    username = Column(String(255), nullable=False, unique=True, index=True)
+    hashed_password = Column(String(1024), nullable=False)
+    email = Column(String(254), nullable=True, unique=True, index=True)
+    date_email_verified = Column(DateTime, nullable=True)

--- a/src/opinionated_mixins/contrib/sqlmodel/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/__init__.py
@@ -3,3 +3,4 @@ from .feedback import Feedback as Feedback
 from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template
+from .user import User as User

--- a/src/opinionated_mixins/contrib/sqlmodel/user.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/user.py
@@ -1,0 +1,3 @@
+from opinionated_mixins.contrib.sqlalchemy.user import (
+    User as User,
+)

--- a/src/opinionated_mixins/contrib/wtforms/__init__.py
+++ b/src/opinionated_mixins/contrib/wtforms/__init__.py
@@ -3,3 +3,4 @@ from .feedback import Feedback as Feedback
 from .lead import Lead as Lead
 from .person import Person as Person
 from .template import Template as Template
+from .user import User as User

--- a/src/opinionated_mixins/contrib/wtforms/lead.py
+++ b/src/opinionated_mixins/contrib/wtforms/lead.py
@@ -1,3 +1,5 @@
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
 from wtforms import (
     BooleanField,
     DateField,
@@ -8,8 +10,6 @@ from wtforms import (
     TextAreaField,
 )
 from wtforms.validators import Length, NumberRange, Optional
-
-from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
 
 
 class Lead:

--- a/src/opinionated_mixins/contrib/wtforms/user.py
+++ b/src/opinionated_mixins/contrib/wtforms/user.py
@@ -1,0 +1,23 @@
+from wtforms import DateTimeField, PasswordField, StringField
+from wtforms.validators import DataRequired, Length, Optional
+
+
+class User:
+    """User mixin for WTForms forms."""
+
+    username = StringField(
+        label="Username",
+        validators=[Length(min=1, max=255), DataRequired()],
+    )
+    password = PasswordField(
+        label="Password",
+        validators=[Length(min=1), DataRequired()],
+    )
+    email = StringField(
+        label="Email",
+        validators=[Length(max=254), Optional()],
+    )
+    date_email_verified = DateTimeField(
+        label="Date Email Verified",
+        validators=[Optional()],
+    )

--- a/tests/dataclasses/test_user.py
+++ b/tests/dataclasses/test_user.py
@@ -1,0 +1,37 @@
+import dataclasses
+import datetime
+
+from opinionated_mixins.contrib.dataclasses import User
+
+
+class TestDataclassesUser:
+    def test_is_dataclass(self) -> None:
+        assert dataclasses.is_dataclass(User)
+
+    def test_create_with_required_only(self) -> None:
+        obj = User(username="janedoe", hashed_password="hashed123")
+        assert obj.username == "janedoe"
+        assert obj.hashed_password == "hashed123"
+        assert obj.email is None
+        assert obj.date_email_verified is None
+
+    def test_create_with_all_fields(self) -> None:
+        now = datetime.datetime(2024, 1, 15, 12, 0, 0)
+        obj = User(
+            username="janedoe",
+            hashed_password="hashed123",
+            email="jane@example.com",
+            date_email_verified=now,
+        )
+        assert obj.email == "jane@example.com"
+        assert obj.date_email_verified == now
+
+    def test_fields(self) -> None:
+        fields = {f.name for f in dataclasses.fields(User)}
+        expected = {
+            "username",
+            "hashed_password",
+            "email",
+            "date_email_verified",
+        }
+        assert fields == expected

--- a/tests/mongoengine/test_user.py
+++ b/tests/mongoengine/test_user.py
@@ -1,0 +1,24 @@
+from opinionated_mixins.contrib.mongoengine import User
+
+
+class TestMongoEngineUser:
+    def test_has_username_field(self) -> None:
+        assert hasattr(User, "username")
+        assert User.username.required is True
+        assert User.username.max_length == 255
+        assert User.username.unique is True
+
+    def test_has_hashed_password_field(self) -> None:
+        assert hasattr(User, "hashed_password")
+        assert User.hashed_password.required is True
+        assert User.hashed_password.max_length == 1024
+
+    def test_has_email_field(self) -> None:
+        assert hasattr(User, "email")
+        assert User.email.required is False
+        assert User.email.max_length == 254
+        assert User.email.unique is True
+
+    def test_has_date_email_verified_field(self) -> None:
+        assert hasattr(User, "date_email_verified")
+        assert User.date_email_verified.required is False

--- a/tests/odmantic/test_lead.py
+++ b/tests/odmantic/test_lead.py
@@ -1,6 +1,5 @@
 from opinionated_mixins.contrib.odmantic import Lead
 
-
 LEAD_ANNOTATIONS = {
     "title",
     "salutation",

--- a/tests/odmantic/test_user.py
+++ b/tests/odmantic/test_user.py
@@ -1,0 +1,18 @@
+from opinionated_mixins.contrib.odmantic import User
+
+
+class TestODManticUser:
+    def test_has_expected_annotations(self) -> None:
+        annotations = User.__annotations__
+        assert "username" in annotations
+        assert "hashed_password" in annotations
+        assert "email" in annotations
+        assert "date_email_verified" in annotations
+
+    def test_optional_fields_default_none(self) -> None:
+        for field_name in (
+            "email",
+            "date_email_verified",
+        ):
+            field_info = getattr(User, field_name).pydantic_field_info
+            assert field_info.default is None, f"{field_name} should default to None"

--- a/tests/pydantic/test_user.py
+++ b/tests/pydantic/test_user.py
@@ -1,0 +1,49 @@
+import datetime
+
+import pytest
+from opinionated_mixins.contrib.pydantic import User
+from pydantic import ValidationError
+
+
+class TestPydanticUser:
+    def test_create_with_required_only(self) -> None:
+        obj = User(username="janedoe", hashed_password="hashed123")
+        assert obj.username == "janedoe"
+        assert obj.hashed_password == "hashed123"
+        assert obj.email is None
+        assert obj.date_email_verified is None
+
+    def test_create_with_all_fields(self) -> None:
+        now = datetime.datetime(2024, 1, 15, 12, 0, 0)
+        obj = User(
+            username="janedoe",
+            hashed_password="hashed123",
+            email="jane@example.com",
+            date_email_verified=now,
+        )
+        assert obj.email == "jane@example.com"
+        assert obj.date_email_verified == now
+
+    def test_username_required(self) -> None:
+        with pytest.raises(ValidationError):
+            User(hashed_password="hashed123")  # type: ignore[call-arg]
+
+    def test_hashed_password_required(self) -> None:
+        with pytest.raises(ValidationError):
+            User(username="janedoe")  # type: ignore[call-arg]
+
+    def test_empty_username_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            User(username="", hashed_password="hashed123")
+
+    def test_username_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            User(username="x" * 256, hashed_password="hashed123")
+
+    def test_empty_hashed_password_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            User(username="janedoe", hashed_password="")
+
+    def test_email_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            User(username="janedoe", hashed_password="hashed123", email="x" * 255)

--- a/tests/sqlalchemy/test_user.py
+++ b/tests/sqlalchemy/test_user.py
@@ -1,0 +1,70 @@
+import datetime
+
+from opinionated_mixins.contrib.sqlalchemy import User
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+Base = declarative_base()
+
+
+class MyUser(User, Base):  # type: ignore[misc]
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+
+
+class TestSQLAlchemyUser:
+    def setup_method(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+
+    def test_create_with_required_only(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyUser(username="janedoe", hashed_password="hashed123")
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.username == "janedoe"
+            assert obj.hashed_password == "hashed123"
+            assert obj.email is None
+            assert obj.date_email_verified is None
+
+    def test_create_with_all_fields(self) -> None:
+        with Session(self.engine) as session:
+            now = datetime.datetime(2024, 1, 15, 12, 0, 0)
+            obj = MyUser(
+                username="janedoe",
+                hashed_password="hashed123",
+                email="jane@example.com",
+                date_email_verified=now,
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.email == "jane@example.com"
+            assert obj.date_email_verified == now
+
+    def test_fields_exist(self) -> None:
+        columns = {c.name for c in MyUser.__table__.columns}
+        expected = {
+            "username",
+            "hashed_password",
+            "email",
+            "date_email_verified",
+        }
+        assert expected.issubset(columns)
+
+    def test_username_unique_constraint(self) -> None:
+        col = MyUser.__table__.c.username
+        assert col.unique is True
+
+    def test_username_index(self) -> None:
+        col = MyUser.__table__.c.username
+        assert col.index is True
+
+    def test_email_unique_constraint(self) -> None:
+        col = MyUser.__table__.c.email
+        assert col.unique is True
+
+    def test_email_index(self) -> None:
+        col = MyUser.__table__.c.email
+        assert col.index is True

--- a/tests/sqlmodel/test_user.py
+++ b/tests/sqlmodel/test_user.py
@@ -1,0 +1,10 @@
+from opinionated_mixins.contrib.sqlmodel import User
+
+
+class TestSQLModelUser:
+    def test_reexports_sqlalchemy(self) -> None:
+        from opinionated_mixins.contrib.sqlalchemy import (
+            User as SAUser,
+        )
+
+        assert User is SAUser

--- a/tests/wtforms/test_user.py
+++ b/tests/wtforms/test_user.py
@@ -1,0 +1,59 @@
+from opinionated_mixins.contrib.wtforms import User
+from wtforms import Form
+
+
+class UserForm(User, Form):  # type: ignore[misc]
+    pass
+
+
+USER_FIELDS = {
+    "username",
+    "password",
+    "email",
+    "date_email_verified",
+}
+
+
+class TestWTFormsUser:
+    def test_has_fields(self) -> None:
+        form = UserForm()
+        for field_name in USER_FIELDS:
+            assert field_name in form._fields, f"Missing field: {field_name}"
+
+    def test_valid_submission_required_only(self) -> None:
+        form = UserForm(
+            data={
+                "username": "janedoe",
+                "password": "secret123",
+            },
+        )
+        assert form.validate()
+
+    def test_valid_submission_all_fields(self) -> None:
+        form = UserForm(
+            data={
+                "username": "janedoe",
+                "password": "secret123",
+                "email": "jane@example.com",
+                "date_email_verified": "2024-01-15 12:00:00",
+            },
+        )
+        assert form.validate()
+
+    def test_missing_username_invalid(self) -> None:
+        form = UserForm(
+            data={
+                "password": "secret123",
+            },
+        )
+        assert not form.validate()
+        assert "username" in form.errors
+
+    def test_missing_password_invalid(self) -> None:
+        form = UserForm(
+            data={
+                "username": "janedoe",
+            },
+        )
+        assert not form.validate()
+        assert "password" in form.errors


### PR DESCRIPTION
## Summary

- Add `User` mixin with `username`, `hashed_password`, `email`, and `date_email_verified` fields across all 7 contrib modules (sqlalchemy, pydantic, mongoengine, odmantic, wtforms, dataclasses, sqlmodel)
- WTForms uses `password` (PasswordField) instead of `hashed_password` since forms handle user input, not storage
- SQLModel re-exports from SQLAlchemy as per project convention

## Fields

| Field | Type | Unique | Required | Index |
|-------|------|--------|----------|-------|
| `username` | `str` (max 255) | Yes | Yes | Yes |
| `hashed_password` | `str` (max 1024) | No | Yes | No |
| `email` | `str` (max 254) | Yes | No | Yes |
| `date_email_verified` | `datetime` | No | No | No |

## Test plan

- [x] 31 new tests across all 7 frameworks
- [x] Full suite passes (207/207)
- [x] Ruff format clean
- [x] No new mypy errors

Closes #3

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a new `User` mixin across all seven contrib framework modules (SQLAlchemy, SQLModel, Pydantic, MongoEngine, ODMantic, dataclasses, and WTForms). The mixin provides four standardized fields: `username` (required, unique, indexed), `hashed_password` (required), `email` (optional, unique, indexed), and `date_email_verified` (optional datetime). WTForms uses a `password` field instead of `hashed_password` since it handles user input rather than storage. The implementation includes comprehensive test coverage with 31 new tests validating field constraints, uniqueness requirements, and validation behavior across all frameworks.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/opinionated_mixins/contrib/sqlalchemy/user.py` |
| 2 | `src/opinionated_mixins/contrib/sqlmodel/user.py` |
| 3 | `src/opinionated_mixins/contrib/pydantic/user.py` |
| 4 | `src/opinionated_mixins/contrib/mongoengine/user.py` |
| 5 | `src/opinionated_mixins/contrib/odmantic/user.py` |
| 6 | `src/opinionated_mixins/contrib/dataclasses/user.py` |
| 7 | `src/opinionated_mixins/contrib/wtforms/user.py` |
| 8 | `tests/sqlalchemy/test_user.py` |
| 9 | `tests/sqlmodel/test_user.py` |
| 10 | `tests/pydantic/test_user.py` |
| 11 | `tests/mongoengine/test_user.py` |
| 12 | `tests/odmantic/test_user.py` |
| 13 | `tests/dataclasses/test_user.py` |
| 14 | `tests/wtforms/test_user.py` |
| 15 | `src/opinionated_mixins/contrib/sqlalchemy/__init__.py` |
| 16 | `src/opinionated_mixins/contrib/sqlmodel/__init__.py` |
| 17 | `src/opinionated_mixins/contrib/pydantic/__init__.py` |
| 18 | `src/opinionated_mixins/contrib/mongoengine/__init__.py` |
| 19 | `src/opinionated_mixins/contrib/odmantic/__init__.py` |
| 20 | `src/opinionated_mixins/contrib/dataclasses/__init__.py` |
| 21 | `src/opinionated_mixins/contrib/wtforms/__init__.py` |
| 22 | `src/opinionated_mixins/contrib/pydantic/lead.py` |
| 23 | `src/opinionated_mixins/contrib/sqlalchemy/announcement.py` |
| 24 | `src/opinionated_mixins/contrib/mongoengine/lead.py` |
| 25 | `src/opinionated_mixins/contrib/odmantic/lead.py` |
| 26 | `src/opinionated_mixins/contrib/wtforms/lead.py` |
| 27 | `src/opinionated_mixins/contrib/dataclasses/lead.py` |
| 28 | `tests/odmantic/test_lead.py` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `src/opinionated_mixins/contrib/pydantic/lead.py` | Contains an unrelated formatting change to the `opportunity_amount` field (trailing comma) that is not related to adding the User mixin |
| `src/opinionated_mixins/contrib/sqlalchemy/announcement.py` | Contains an unrelated formatting change (trailing comma in the Enum column definition) that is not related to adding the User mixin |
| `src/opinionated_mixins/contrib/mongoengine/lead.py` | Contains import reordering that is not related to adding the User mixin |
| `src/opinionated_mixins/contrib/odmantic/lead.py` | Contains import reordering that is not related to adding the User mixin |
| `src/opinionated_mixins/contrib/wtforms/lead.py` | Contains import reordering that is not related to adding the User mixin |
| `src/opinionated_mixins/contrib/dataclasses/lead.py` | Contains import reordering that is not related to adding the User mixin |
| `tests/odmantic/test_lead.py` | Contains removal of a blank line that is not related to adding the User mixin |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->