### PR TITLE
fix: remove BaseModel inheritance from Pydantic mixins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ src/opinionated_mixins/
 ├── __about__.py         # Version (single source of truth for hatchling)
 ├── enums.py             # Shared enums used across all contrib modules
 └── contrib/             # Framework-specific implementations
-    ├── pydantic/        # Pydantic BaseModel mixins
+    ├── pydantic/        # Pydantic mixins
     ├── sqlalchemy/      # SQLAlchemy declarative mixins
     ├── sqlmodel/        # SQLModel mixins (re-exports from sqlalchemy)
     ├── mongoengine/     # MongoEngine Document mixins
@@ -64,6 +64,26 @@ src/opinionated_mixins/
     ├── wtforms/         # WTForms mixins
     └── dataclasses/     # stdlib dataclass mixins
 ```
+
+### What Is a Mixin
+
+A mixin is a plain class that provides fields/methods to other classes through multiple inheritance, **without being a standalone base class**. Rules:
+
+1. **Never inherit from a framework base** — no `class Foo(BaseModel)`, no `class Foo(Document)`. The mixin is a plain `class Foo:`. The consumer picks the base.
+2. **Not independently instantiable** — mixins are composed, not used alone: `class MyModel(AnnouncementMixin, BaseModel): pass`.
+3. **Composable** — multiple mixins combine freely with any compatible base.
+
+```python
+# ✅ Correct — true mixin
+class Announcement:
+    title: str = Field(..., min_length=1, max_length=255)
+
+# ❌ Wrong — couples to framework base
+class Announcement(BaseModel):
+    title: str = Field(..., min_length=1, max_length=255)
+```
+
+This applies to **all** contrib modules. Every mixin class must be a plain class with no parent.
 
 ### Key Design Principles
 
@@ -76,7 +96,7 @@ src/opinionated_mixins/
 Each framework expresses the same fields differently:
 
 - **SQLAlchemy**: `Column(String(255), nullable=False, index=True)`, uses `@declarative_mixin` and `__abstract__ = True`
-- **Pydantic**: `Field(..., min_length=1, max_length=255)` on `BaseModel`
+- **Pydantic**: `Field(..., min_length=1, max_length=255)` — plain class, user composes with `BaseModel`
 - **MongoEngine**: `StringField(required=True, max_length=255)` with `choices` for enums, uses `.value` for enum defaults
 - **ODMantic**: `Field(...)` similar to Pydantic syntax
 - **WTForms**: `StringField(label="...", validators=[...])` with `SelectField` for enums, uses `.value` for defaults/choices

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ class MyAnnouncement(Base, Announcement):
 Switch to Pydantic? Same fields, same names:
 
 ```python
+from pydantic import BaseModel
 from opinionated_mixins.contrib.pydantic import Announcement
 
-class MyAnnouncement(Announcement):
+class MyAnnouncement(Announcement, BaseModel):
     id: int
     # Same: title, content, category — with Pydantic validation
 ```
@@ -59,7 +60,7 @@ class MyAnnouncement(Announcement):
 | --------------- | ----------------------------- | ----------------------------- |
 | **SQLAlchemy**  | SQL ORM                       | Declarative model mixins      |
 | **SQLModel**    | SQL ORM (Pydantic + SA)       | Re-exports SQLAlchemy mixins  |
-| **Pydantic**    | Data validation               | BaseModel mixins with `Field` |
+| **Pydantic**    | Data validation               | Plain mixins with `Field`, compose with `BaseModel` |
 | **MongoEngine** | MongoDB ODM                   | Document field mixins         |
 | **ODMantic**    | MongoDB async ODM             | Model field mixins            |
 | **WTForms**     | Form validation               | Form field mixins             |
@@ -67,11 +68,16 @@ class MyAnnouncement(Announcement):
 
 ## Available Mixins
 
-| Mixin | Fields | Shared Enum |
-| ----- | ------ | ----------- |
+| Mixin | Fields | Shared Enums |
+| ----- | ------ | ------------ |
 | **Announcement** | `title`, `content`, `category` | `AnnouncementCategory` (8 values) |
+| **Feedback** | `subject`, `content`, `category`, `status` | `FeedbackCategory` (4), `FeedbackStatus` (4) |
+| **Lead** | `title`, `salutation`, `job_title`, `company_name`, `website`, `linkedin_url`, `status`, `source`, `industry`, `rating`, `opportunity_amount`, `currency`, `probability`, `close_date`, `last_contacted`, `next_follow_up`, `description`, `is_active` | `LeadStatus` (5), `LeadSource` (7), `LeadRating` (3) |
+| **Person** | `first_name`, `last_name`, `middle_name`, `phone_number`, `email`, `street_address`, `postal_code`, `city`, `country`, `date_of_birth`, `bio` | — |
+| **Template** | `name`, `content`, `format`, `type` | `TemplateFormat` (3), `TemplateType` (4) |
+| **User** | `username`, `hashed_password`, `email`, `date_email_verified` | — |
 
-More coming — see [open proposals](https://github.com/hasansezertasan/opinionated-mixins/issues?q=is%3Aopen+label%3Amodel-proposal).
+See [open proposals](https://github.com/hasansezertasan/opinionated-mixins/issues?q=is%3Aopen+label%3Amodel-proposal) for upcoming mixins.
 
 ## Installation
 

--- a/src/opinionated_mixins/contrib/pydantic/announcement.py
+++ b/src/opinionated_mixins/contrib/pydantic/announcement.py
@@ -1,9 +1,9 @@
 from opinionated_mixins.enums import AnnouncementCategory
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 
-class Announcement(BaseModel):
+class Announcement:
     """Announcement mixin for Pydantic models."""
 
     title: str = Field(..., min_length=1, max_length=255)

--- a/src/opinionated_mixins/contrib/pydantic/feedback.py
+++ b/src/opinionated_mixins/contrib/pydantic/feedback.py
@@ -1,9 +1,9 @@
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 
-class Feedback(BaseModel):
+class Feedback:
     """Feedback mixin for Pydantic models."""
 
     subject: str = Field(..., min_length=1, max_length=255)

--- a/src/opinionated_mixins/contrib/pydantic/lead.py
+++ b/src/opinionated_mixins/contrib/pydantic/lead.py
@@ -3,10 +3,10 @@ from decimal import Decimal
 
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 
-class Lead(BaseModel):
+class Lead:
     """Lead mixin for Pydantic models."""
 
     title: str | None = Field(default=None, max_length=255)

--- a/src/opinionated_mixins/contrib/pydantic/person.py
+++ b/src/opinionated_mixins/contrib/pydantic/person.py
@@ -1,9 +1,9 @@
 import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 
-class Person(BaseModel):
+class Person:
     """Person mixin for Pydantic models."""
 
     first_name: str = Field(..., min_length=1, max_length=255)

--- a/src/opinionated_mixins/contrib/pydantic/template.py
+++ b/src/opinionated_mixins/contrib/pydantic/template.py
@@ -1,9 +1,9 @@
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 
-class Template(BaseModel):
+class Template:
     """Template mixin for Pydantic models."""
 
     name: str = Field(..., min_length=1, max_length=255)

--- a/src/opinionated_mixins/contrib/pydantic/user.py
+++ b/src/opinionated_mixins/contrib/pydantic/user.py
@@ -1,9 +1,9 @@
 import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 
-class User(BaseModel):
+class User:
     """User mixin for Pydantic models."""
 
     username: str = Field(..., min_length=1, max_length=255)

--- a/tests/pydantic/test_announcement.py
+++ b/tests/pydantic/test_announcement.py
@@ -1,18 +1,22 @@
 import pytest
 from opinionated_mixins.contrib.pydantic import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
+
+
+class AnnouncementModel(Announcement, BaseModel):
+    pass
 
 
 class TestPydanticAnnouncement:
     def test_create_with_defaults(self) -> None:
-        obj = Announcement(title="Test", content="Hello world")
+        obj = AnnouncementModel(title="Test", content="Hello world")
         assert obj.title == "Test"
         assert obj.content == "Hello world"
         assert obj.category == AnnouncementCategory.GENERAL
 
     def test_create_with_category(self) -> None:
-        obj = Announcement(
+        obj = AnnouncementModel(
             title="Update",
             content="New feature",
             category=AnnouncementCategory.UPDATE,
@@ -21,24 +25,24 @@ class TestPydanticAnnouncement:
 
     def test_title_required(self) -> None:
         with pytest.raises(ValidationError):
-            Announcement(content="No title")  # type: ignore[call-arg]
+            AnnouncementModel(content="No title")  # type: ignore[call-arg]
 
     def test_content_required(self) -> None:
         with pytest.raises(ValidationError):
-            Announcement(title="No content")  # type: ignore[call-arg]
+            AnnouncementModel(title="No content")  # type: ignore[call-arg]
 
     def test_empty_title_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Announcement(title="", content="Body")
+            AnnouncementModel(title="", content="Body")
 
     def test_title_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            Announcement(title="x" * 256, content="Body")
+            AnnouncementModel(title="x" * 256, content="Body")
 
     def test_category_from_string(self) -> None:
-        obj = Announcement(title="Test", content="Body", category="warning")  # type: ignore[arg-type]
+        obj = AnnouncementModel(title="Test", content="Body", category="warning")  # type: ignore[arg-type]
         assert obj.category == AnnouncementCategory.WARNING
 
     def test_invalid_category_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Announcement(title="Test", content="Body", category="invalid")  # type: ignore[arg-type]
+            AnnouncementModel(title="Test", content="Body", category="invalid")  # type: ignore[arg-type]

--- a/tests/pydantic/test_composition.py
+++ b/tests/pydantic/test_composition.py
@@ -1,0 +1,61 @@
+import pytest
+from opinionated_mixins.contrib.pydantic import Announcement, Person, User
+from opinionated_mixins.enums import AnnouncementCategory
+from pydantic import BaseModel, ValidationError
+
+
+class CombinedModel(User, Person, Announcement, BaseModel):
+    pass
+
+
+class TestPydanticMixinComposition:
+    def test_all_fields_available(self) -> None:
+        obj = CombinedModel(
+            username="jdoe",
+            hashed_password="hashed123",
+            first_name="John",
+            last_name="Doe",
+            title="Test announcement",
+            content="Hello world",
+        )
+        assert obj.username == "jdoe"
+        assert obj.hashed_password == "hashed123"
+        assert obj.first_name == "John"
+        assert obj.last_name == "Doe"
+        assert obj.title == "Test announcement"
+        assert obj.content == "Hello world"
+        assert obj.category == AnnouncementCategory.GENERAL
+
+    def test_validation_runs_across_all_mixins(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            CombinedModel(
+                username="",
+                hashed_password="hashed123",
+                first_name="",
+                last_name="Doe",
+                title="",
+                content="Body",
+            )
+        errors = exc_info.value.errors()
+        fields_with_errors = {e["loc"][0] for e in errors}
+        assert "username" in fields_with_errors
+        assert "first_name" in fields_with_errors
+        assert "title" in fields_with_errors
+
+    def test_optional_fields_from_multiple_mixins(self) -> None:
+        obj = CombinedModel(
+            username="jdoe",
+            hashed_password="hashed123",
+            first_name="Jane",
+            last_name="Doe",
+            email="jane@example.com",
+            phone_number="+1234567890",
+            country="US",
+            title="Update",
+            content="New feature",
+            category=AnnouncementCategory.UPDATE,
+        )
+        assert obj.email == "jane@example.com"
+        assert obj.phone_number == "+1234567890"
+        assert obj.country == "US"
+        assert obj.category == AnnouncementCategory.UPDATE

--- a/tests/pydantic/test_feedback.py
+++ b/tests/pydantic/test_feedback.py
@@ -1,19 +1,23 @@
 import pytest
 from opinionated_mixins.contrib.pydantic import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
+
+
+class FeedbackModel(Feedback, BaseModel):
+    pass
 
 
 class TestPydanticFeedback:
     def test_create_with_defaults(self) -> None:
-        obj = Feedback(subject="Bug report", content="Something broke")
+        obj = FeedbackModel(subject="Bug report", content="Something broke")
         assert obj.subject == "Bug report"
         assert obj.content == "Something broke"
         assert obj.category == FeedbackCategory.OTHER
         assert obj.status == FeedbackStatus.PENDING
 
     def test_create_with_explicit_values(self) -> None:
-        obj = Feedback(
+        obj = FeedbackModel(
             subject="Feature idea",
             content="Add dark mode",
             category=FeedbackCategory.FEATURE,
@@ -24,32 +28,32 @@ class TestPydanticFeedback:
 
     def test_subject_required(self) -> None:
         with pytest.raises(ValidationError):
-            Feedback(content="No subject")  # type: ignore[call-arg]
+            FeedbackModel(content="No subject")  # type: ignore[call-arg]
 
     def test_content_required(self) -> None:
         with pytest.raises(ValidationError):
-            Feedback(subject="No content")  # type: ignore[call-arg]
+            FeedbackModel(subject="No content")  # type: ignore[call-arg]
 
     def test_empty_subject_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Feedback(subject="", content="Body")
+            FeedbackModel(subject="", content="Body")
 
     def test_subject_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            Feedback(subject="x" * 256, content="Body")
+            FeedbackModel(subject="x" * 256, content="Body")
 
     def test_category_from_string(self) -> None:
-        obj = Feedback(subject="Test", content="Body", category="bug")  # type: ignore[arg-type]
+        obj = FeedbackModel(subject="Test", content="Body", category="bug")  # type: ignore[arg-type]
         assert obj.category == FeedbackCategory.BUG
 
     def test_invalid_category_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Feedback(subject="Test", content="Body", category="invalid")  # type: ignore[arg-type]
+            FeedbackModel(subject="Test", content="Body", category="invalid")  # type: ignore[arg-type]
 
     def test_status_from_string(self) -> None:
-        obj = Feedback(subject="Test", content="Body", status="reviewed")  # type: ignore[arg-type]
+        obj = FeedbackModel(subject="Test", content="Body", status="reviewed")  # type: ignore[arg-type]
         assert obj.status == FeedbackStatus.REVIEWED
 
     def test_invalid_status_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Feedback(subject="Test", content="Body", status="invalid")  # type: ignore[arg-type]
+            FeedbackModel(subject="Test", content="Body", status="invalid")  # type: ignore[arg-type]

--- a/tests/pydantic/test_lead.py
+++ b/tests/pydantic/test_lead.py
@@ -4,19 +4,23 @@ from decimal import Decimal
 import pytest
 from opinionated_mixins.contrib.pydantic import Lead
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
+
+
+class LeadModel(Lead, BaseModel):
+    pass
 
 
 class TestPydanticLead:
     def test_create_defaults(self) -> None:
-        obj = Lead()
+        obj = LeadModel()
         assert obj.title is None
         assert obj.status is None
         assert obj.probability == 0
         assert obj.is_active is True
 
     def test_create_with_all_fields(self) -> None:
-        obj = Lead(
+        obj = LeadModel(
             title="Dr.",
             salutation="Dr.",
             job_title="CTO",
@@ -42,24 +46,24 @@ class TestPydanticLead:
 
     def test_title_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            Lead(title="x" * 256)
+            LeadModel(title="x" * 256)
 
     def test_status_from_string(self) -> None:
-        obj = Lead(status="assigned")
+        obj = LeadModel(status="assigned")
         assert obj.status == LeadStatus.ASSIGNED
 
     def test_invalid_status_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Lead(status="invalid")
+            LeadModel(status="invalid")
 
     def test_probability_range(self) -> None:
         with pytest.raises(ValidationError):
-            Lead(probability=101)
+            LeadModel(probability=101)
         with pytest.raises(ValidationError):
-            Lead(probability=-1)
+            LeadModel(probability=-1)
 
     def test_currency_must_be_three_chars(self) -> None:
         with pytest.raises(ValidationError):
-            Lead(currency="US")
+            LeadModel(currency="US")
         with pytest.raises(ValidationError):
-            Lead(currency="USDD")
+            LeadModel(currency="USDD")

--- a/tests/pydantic/test_person.py
+++ b/tests/pydantic/test_person.py
@@ -2,12 +2,16 @@ import datetime
 
 import pytest
 from opinionated_mixins.contrib.pydantic import Person
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
+
+
+class PersonModel(Person, BaseModel):
+    pass
 
 
 class TestPydanticPerson:
     def test_create_with_required_only(self) -> None:
-        obj = Person(first_name="Jane", last_name="Doe")
+        obj = PersonModel(first_name="Jane", last_name="Doe")
         assert obj.first_name == "Jane"
         assert obj.last_name == "Doe"
         assert obj.middle_name is None
@@ -21,7 +25,7 @@ class TestPydanticPerson:
         assert obj.bio is None
 
     def test_create_with_all_fields(self) -> None:
-        obj = Person(
+        obj = PersonModel(
             first_name="Jane",
             last_name="Doe",
             middle_name="Marie",
@@ -40,32 +44,32 @@ class TestPydanticPerson:
 
     def test_first_name_required(self) -> None:
         with pytest.raises(ValidationError):
-            Person(last_name="Doe")  # type: ignore[call-arg]
+            PersonModel(last_name="Doe")  # type: ignore[call-arg]
 
     def test_last_name_required(self) -> None:
         with pytest.raises(ValidationError):
-            Person(first_name="Jane")  # type: ignore[call-arg]
+            PersonModel(first_name="Jane")  # type: ignore[call-arg]
 
     def test_empty_first_name_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Person(first_name="", last_name="Doe")
+            PersonModel(first_name="", last_name="Doe")
 
     def test_first_name_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            Person(first_name="x" * 256, last_name="Doe")
+            PersonModel(first_name="x" * 256, last_name="Doe")
 
     def test_country_must_be_two_chars(self) -> None:
         with pytest.raises(ValidationError):
-            Person(first_name="Jane", last_name="Doe", country="USA")
+            PersonModel(first_name="Jane", last_name="Doe", country="USA")
 
     def test_country_too_short(self) -> None:
         with pytest.raises(ValidationError):
-            Person(first_name="Jane", last_name="Doe", country="U")
+            PersonModel(first_name="Jane", last_name="Doe", country="U")
 
     def test_phone_number_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            Person(first_name="Jane", last_name="Doe", phone_number="x" * 21)
+            PersonModel(first_name="Jane", last_name="Doe", phone_number="x" * 21)
 
     def test_email_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            Person(first_name="Jane", last_name="Doe", email="x" * 255)
+            PersonModel(first_name="Jane", last_name="Doe", email="x" * 255)

--- a/tests/pydantic/test_template.py
+++ b/tests/pydantic/test_template.py
@@ -1,19 +1,23 @@
 import pytest
 from opinionated_mixins.contrib.pydantic import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
+
+
+class TemplateModel(Template, BaseModel):
+    pass
 
 
 class TestPydanticTemplate:
     def test_create_with_defaults(self) -> None:
-        obj = Template(name="Welcome", content="Hello {{name}}")
+        obj = TemplateModel(name="Welcome", content="Hello {{name}}")
         assert obj.name == "Welcome"
         assert obj.content == "Hello {{name}}"
         assert obj.format == TemplateFormat.PLAIN
         assert obj.type == TemplateType.OTHER
 
     def test_create_with_explicit_values(self) -> None:
-        obj = Template(
+        obj = TemplateModel(
             name="Newsletter",
             content="<h1>News</h1>",
             format=TemplateFormat.HTML,
@@ -24,32 +28,32 @@ class TestPydanticTemplate:
 
     def test_name_required(self) -> None:
         with pytest.raises(ValidationError):
-            Template(content="No name")  # type: ignore[call-arg]
+            TemplateModel(content="No name")  # type: ignore[call-arg]
 
     def test_content_required(self) -> None:
         with pytest.raises(ValidationError):
-            Template(name="No content")  # type: ignore[call-arg]
+            TemplateModel(name="No content")  # type: ignore[call-arg]
 
     def test_empty_name_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Template(name="", content="Body")
+            TemplateModel(name="", content="Body")
 
     def test_name_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            Template(name="x" * 256, content="Body")
+            TemplateModel(name="x" * 256, content="Body")
 
     def test_format_from_string(self) -> None:
-        obj = Template(name="Test", content="Body", format="html")  # type: ignore[arg-type]
+        obj = TemplateModel(name="Test", content="Body", format="html")  # type: ignore[arg-type]
         assert obj.format == TemplateFormat.HTML
 
     def test_invalid_format_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Template(name="Test", content="Body", format="invalid")  # type: ignore[arg-type]
+            TemplateModel(name="Test", content="Body", format="invalid")  # type: ignore[arg-type]
 
     def test_type_from_string(self) -> None:
-        obj = Template(name="Test", content="Body", type="sms")  # type: ignore[arg-type]
+        obj = TemplateModel(name="Test", content="Body", type="sms")  # type: ignore[arg-type]
         assert obj.type == TemplateType.SMS
 
     def test_invalid_type_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            Template(name="Test", content="Body", type="invalid")  # type: ignore[arg-type]
+            TemplateModel(name="Test", content="Body", type="invalid")  # type: ignore[arg-type]

--- a/tests/pydantic/test_user.py
+++ b/tests/pydantic/test_user.py
@@ -2,12 +2,16 @@ import datetime
 
 import pytest
 from opinionated_mixins.contrib.pydantic import User
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
+
+
+class UserModel(User, BaseModel):
+    pass
 
 
 class TestPydanticUser:
     def test_create_with_required_only(self) -> None:
-        obj = User(username="janedoe", hashed_password="hashed123")
+        obj = UserModel(username="janedoe", hashed_password="hashed123")
         assert obj.username == "janedoe"
         assert obj.hashed_password == "hashed123"
         assert obj.email is None
@@ -15,7 +19,7 @@ class TestPydanticUser:
 
     def test_create_with_all_fields(self) -> None:
         now = datetime.datetime(2024, 1, 15, 12, 0, 0)
-        obj = User(
+        obj = UserModel(
             username="janedoe",
             hashed_password="hashed123",
             email="jane@example.com",
@@ -26,24 +30,24 @@ class TestPydanticUser:
 
     def test_username_required(self) -> None:
         with pytest.raises(ValidationError):
-            User(hashed_password="hashed123")  # type: ignore[call-arg]
+            UserModel(hashed_password="hashed123")  # type: ignore[call-arg]
 
     def test_hashed_password_required(self) -> None:
         with pytest.raises(ValidationError):
-            User(username="janedoe")  # type: ignore[call-arg]
+            UserModel(username="janedoe")  # type: ignore[call-arg]
 
     def test_empty_username_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            User(username="", hashed_password="hashed123")
+            UserModel(username="", hashed_password="hashed123")
 
     def test_username_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            User(username="x" * 256, hashed_password="hashed123")
+            UserModel(username="x" * 256, hashed_password="hashed123")
 
     def test_empty_hashed_password_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            User(username="janedoe", hashed_password="")
+            UserModel(username="janedoe", hashed_password="")
 
     def test_email_max_length(self) -> None:
         with pytest.raises(ValidationError):
-            User(username="janedoe", hashed_password="hashed123", email="x" * 255)
+            UserModel(username="janedoe", hashed_password="hashed123", email="x" * 255)


### PR DESCRIPTION
## Summary

- Remove `BaseModel` inheritance from all 6 Pydantic mixin classes, making them true mixins (plain classes with no framework base)
- Update all Pydantic tests to compose mixins with `BaseModel` via `class XModel(Mixin, BaseModel)`, mirroring real usage
- Update CLAUDE.md with mixin definition, rules, and corrected Pydantic references

Closes #30

## Test plan

- [x] All 53 Pydantic tests pass
- [x] Full test suite (207 tests) passes
- [ ] Verify no other code depends on Pydantic mixins being `BaseModel` subclasses

## Summary by Sourcery

Decouple Pydantic contrib mixins from BaseModel and update tests and docs to reflect their use as true mixins composed with framework base classes.

New Features:
- Enable Pydantic mixins to be composed with arbitrary BaseModel subclasses via multiple inheritance instead of acting as standalone BaseModel-derived models.

Enhancements:
- Convert all Pydantic contrib mixin classes into plain classes with no BaseModel inheritance to enforce framework-agnostic composition.
- Adjust Pydantic tests to define concrete BaseModel subclasses that compose the mixins, mirroring real-world usage patterns.
- Clarify project documentation to define mixins formally and correct Pydantic-specific guidance to emphasize plain-class mixins.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR converts all 6 Pydantic mixin classes from `BaseModel` subclasses to true mixins (plain classes with no framework base). The mixins (`Announcement`, `Feedback`, `Lead`, `Person`, `Template`, and `User`) now remove their `BaseModel` inheritance, requiring consumers to compose them with `BaseModel` using multiple inheritance like `class MyModel(Mixin, BaseModel)`. All Pydantic tests have been updated to reflect this pattern by creating test model classes that properly compose the mixins with `BaseModel`. The documentation in `CLAUDE.md` has been updated to include a comprehensive mixin definition section explaining the design principle that mixins should never inherit from framework bases, making them more flexible and reusable across different contexts.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CLAUDE.md` |
| 2 | `src/opinionated_mixins/contrib/pydantic/person.py` |
| 3 | `src/opinionated_mixins/contrib/pydantic/user.py` |
| 4 | `src/opinionated_mixins/contrib/pydantic/announcement.py` |
| 5 | `src/opinionated_mixins/contrib/pydantic/feedback.py` |
| 6 | `src/opinionated_mixins/contrib/pydantic/template.py` |
| 7 | `src/opinionated_mixins/contrib/pydantic/lead.py` |
| 8 | `tests/pydantic/test_person.py` |
| 9 | `tests/pydantic/test_user.py` |
| 10 | `tests/pydantic/test_announcement.py` |
| 11 | `tests/pydantic/test_feedback.py` |
| 12 | `tests/pydantic/test_template.py` |
| 13 | `tests/pydantic/test_lead.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->