### PR TITLE
docs: add framework proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/framework_proposal.md
+++ b/.github/ISSUE_TEMPLATE/framework_proposal.md
@@ -1,0 +1,55 @@
+---
+name: Framework Proposal
+about: Propose adding support for a new ORM or ODM framework
+title: 'Framework Proposal: '
+labels: framework-proposal
+assignees: ''
+
+---
+
+**Which framework are you proposing?**
+Name, PyPI package, and link to documentation.
+
+| Detail | Value |
+| ------ | ----- |
+| Package name | e.g. `tortoise-orm` |
+| PyPI link | e.g. https://pypi.org/project/tortoise-orm/ |
+| Docs link | |
+| Type | ORM / ODM |
+| Database backends | e.g. PostgreSQL, MySQL, SQLite |
+| Python version support | e.g. 3.10+ |
+
+**Why should this framework be supported?**
+A clear and concise explanation of why this framework belongs in the project. Consider adoption, community size, and use cases not covered by existing contrib modules.
+
+**Ecosystem evidence**
+Show that this framework has meaningful adoption. Include at least 3 data points.
+
+| Metric | Value | Link |
+| ------ | ----- | ---- |
+| GitHub stars | | |
+| PyPI monthly downloads | | |
+| Last release date | | |
+| Other (Stack Overflow tags, Discord members, etc.) | | |
+
+**Mixin implementation idioms**
+Describe how mixins would be expressed in this framework. Show a short example of a field definition and a mixin class.
+
+```python
+# Example: how does this framework define a string field with max_length, required, and indexed?
+```
+
+```python
+# Example: how would a mixin class look? (plain class, abstract base, metaclass, etc.)
+```
+
+**Key questions**
+- Can mixins be plain classes (no framework base), consistent with this project's mixin rules?
+- Does the framework support enum fields natively or require a workaround?
+- Can it re-export from an existing contrib module (like SQLModel re-exports from SQLAlchemy), or does it need a full implementation?
+
+**Existing contrib modules**
+For reference, the project currently supports: SQLAlchemy, SQLModel (re-exports SQLAlchemy), MongoEngine, ODMantic.
+
+**Additional context**
+Add any other context, links, or screenshots here.


### PR DESCRIPTION
## Summary
- Add new issue template for proposing ORM/ODM framework support
- Covers framework identification, ecosystem evidence, mixin idiom compatibility, and re-export feasibility
- Follows existing template conventions (model_proposal, field_proposal)

## Test plan
- [ ] Verify template renders correctly on GitHub Issues → New Issue
- [ ] Confirm all table columns display properly
- [ ] Check code fence examples render as expected

## Summary by Sourcery

Documentation:
- Document a structured process for requesting new ORM/ODM framework integrations via a dedicated GitHub issue template.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new GitHub issue template for proposing support for new ORM/ODM frameworks. The template guides contributors to provide framework details, ecosystem adoption metrics, mixin implementation examples, and compatibility information with the project's existing architecture. It follows the same conventions as existing proposal templates like `model_proposal` and `field_proposal`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/ISSUE_TEMPLATE/framework_proposal.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->