### PR TITLE
test: add integration tests for MongoEngine and ODMantic mixins

### DIFF
--- a/examples/flask_admin_mongoengine/app.py
+++ b/examples/flask_admin_mongoengine/app.py
@@ -1,0 +1,266 @@
+"""Flask-Admin example showcasing all opinionated-mixins with MongoEngine.
+
+Run with real MongoDB:
+    pip install flask flask-admin mongoengine opinionated-mixins
+    python app.py
+
+Run without MongoDB (mongomock):
+    pip install flask flask-admin mongoengine mongomock opinionated-mixins
+    MONGOMOCK=1 python app.py
+
+Then visit http://localhost:5000/admin/
+"""
+
+from __future__ import annotations
+
+import os
+
+import mongoengine
+from flask import Flask
+from flask_admin import Admin
+from flask_admin.contrib.mongoengine import ModelView
+from mongoengine import Document
+from opinionated_mixins.contrib.mongoengine import (
+    Announcement,
+    CreatedAt,
+    Feedback,
+    IsActive,
+    Lead,
+    Person,
+    Template,
+    UpdatedAt,
+    User,
+)
+from opinionated_mixins.enums import (
+    AnnouncementCategory,
+    FeedbackCategory,
+    FeedbackStatus,
+    LeadRating,
+    LeadSource,
+    LeadStatus,
+    TemplateFormat,
+    TemplateType,
+)
+
+# ---------------------------------------------------------------------------
+# Document models
+# ---------------------------------------------------------------------------
+
+
+class AnnouncementDoc(CreatedAt, IsActive, Announcement, Document):
+    """Announcement with creation timestamp and soft-delete."""
+
+    meta = {"collection": "announcements"}
+
+
+class FeedbackDoc(CreatedAt, UpdatedAt, Feedback, Document):
+    """Feedback with both timestamps."""
+
+    meta = {"collection": "feedbacks"}
+
+
+class TemplateDoc(CreatedAt, UpdatedAt, Template, Document):
+    """Template with both timestamps."""
+
+    meta = {"collection": "templates"}
+
+
+class LeadDoc(CreatedAt, UpdatedAt, Lead, Document):
+    """Lead with both timestamps.
+
+    Note: Lead mixin already includes its own ``is_active`` field,
+    so the separate ``IsActive`` mixin is not needed here.
+    """
+
+    meta = {"collection": "leads"}
+
+
+class PersonDoc(Person, Document):
+    """Person document."""
+
+    meta = {"collection": "persons"}
+
+
+class UserDoc(CreatedAt, User, Document):
+    """User with creation timestamp."""
+
+    meta = {"collection": "users"}
+
+
+# ---------------------------------------------------------------------------
+# Flask-Admin views
+# ---------------------------------------------------------------------------
+
+
+class AnnouncementAdmin(ModelView):
+    """Admin view for announcements."""
+
+    column_list = ["title", "category", "is_active", "created_at"]
+    column_searchable_list = ["title", "content"]
+    column_filters = ["category", "is_active", "created_at"]
+    form_choices = {
+        "category": [(c.value, c.name) for c in AnnouncementCategory],
+    }
+
+
+class FeedbackAdmin(ModelView):
+    """Admin view for feedback submissions."""
+
+    column_list = ["subject", "category", "status", "created_at", "updated_at"]
+    column_searchable_list = ["subject", "content"]
+    column_filters = ["category", "status"]
+    form_choices = {
+        "category": [(c.value, c.name) for c in FeedbackCategory],
+        "status": [(s.value, s.name) for s in FeedbackStatus],
+    }
+
+
+class TemplateAdmin(ModelView):
+    """Admin view for templates."""
+
+    column_list = ["name", "format", "type", "created_at", "updated_at"]
+    column_searchable_list = ["name", "content"]
+    column_filters = ["format", "type"]
+    form_choices = {
+        "format": [(f.value, f.name) for f in TemplateFormat],
+        "type": [(t.value, t.name) for t in TemplateType],
+    }
+
+
+class LeadAdmin(ModelView):
+    """Admin view for leads."""
+
+    column_list = [
+        "title",
+        "company_name",
+        "status",
+        "source",
+        "rating",
+        "opportunity_amount",
+        "is_active",
+        "created_at",
+    ]
+    column_searchable_list = ["title", "company_name"]
+    column_filters = ["status", "source", "rating", "is_active"]
+    form_choices = {
+        "status": [(s.value, s.name) for s in LeadStatus],
+        "source": [(s.value, s.name) for s in LeadSource],
+        "rating": [(r.value, r.name) for r in LeadRating],
+    }
+
+
+class PersonAdmin(ModelView):
+    """Admin view for persons."""
+
+    column_list = [
+        "first_name",
+        "last_name",
+        "email",
+        "phone_number",
+        "city",
+        "country",
+    ]
+    column_searchable_list = ["first_name", "last_name", "email"]
+    column_filters = ["country", "city"]
+
+
+class UserAdmin(ModelView):
+    """Admin view for users."""
+
+    column_list = ["username", "email", "date_email_verified", "created_at"]
+    column_searchable_list = ["username", "email"]
+    column_filters = ["date_email_verified", "created_at"]
+    form_excluded_columns = ["hashed_password"]
+
+
+# ---------------------------------------------------------------------------
+# Seed data
+# ---------------------------------------------------------------------------
+
+
+def seed() -> None:
+    """Insert sample records so the admin UI isn't empty on first launch."""
+    if AnnouncementDoc.objects.count():
+        return
+
+    AnnouncementDoc(
+        title="Scheduled maintenance",
+        content="Systems will be down Saturday 02:00-04:00 UTC.",
+        category=AnnouncementCategory.MAINTENANCE.value,
+    ).save()
+    AnnouncementDoc(
+        title="New feature: Dark mode",
+        content="Dark mode is now available in settings.",
+        category=AnnouncementCategory.UPDATE.value,
+    ).save()
+    FeedbackDoc(
+        subject="Login page slow",
+        content="Takes 5+ seconds to load on mobile.",
+        category=FeedbackCategory.BUG.value,
+        status=FeedbackStatus.PENDING.value,
+    ).save()
+    TemplateDoc(
+        name="Welcome email",
+        content="Hi {{ name }}, welcome aboard!",
+        format=TemplateFormat.HTML.value,
+        type=TemplateType.EMAIL.value,
+    ).save()
+    LeadDoc(
+        title="Mr.",
+        company_name="Acme Corp",
+        status=LeadStatus.IN_PROCESS.value,
+        source=LeadSource.CALL.value,
+        rating=LeadRating.HOT.value,
+    ).save()
+    PersonDoc(
+        first_name="Ada",
+        last_name="Lovelace",
+        email="ada@example.com",
+        city="London",
+        country="GB",
+    ).save()
+    UserDoc(
+        username="admin",
+        hashed_password="pbkdf2:sha256:placeholder",
+        email="admin@example.com",
+    ).save()
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "dev-only-secret-key"
+
+    if os.environ.get("MONGOMOCK"):
+        import mongomock
+
+        mongoengine.connect(
+            "opinionated_mixins_demo",
+            mongo_client_class=mongomock.MongoClient,
+        )
+    else:
+        mongoengine.connect(
+            "opinionated_mixins_demo",
+            host="mongodb://localhost:27017",
+        )
+
+    seed()
+
+    admin = Admin(app, name="Opinionated Mixins (Mongo)", template_mode="bootstrap4")
+    admin.add_view(AnnouncementAdmin(AnnouncementDoc, name="Announcements"))
+    admin.add_view(FeedbackAdmin(FeedbackDoc, name="Feedback"))
+    admin.add_view(TemplateAdmin(TemplateDoc, name="Templates"))
+    admin.add_view(LeadAdmin(LeadDoc, name="Leads"))
+    admin.add_view(PersonAdmin(PersonDoc, name="Persons"))
+    admin.add_view(UserAdmin(UserDoc, name="Users"))
+
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(debug=True)

--- a/examples/flask_admin_sqlalchemy/app.py
+++ b/examples/flask_admin_sqlalchemy/app.py
@@ -36,7 +36,7 @@ from opinionated_mixins.enums import (
     TemplateType,
 )
 from sqlalchemy import create_engine
-from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, Session, scoped_session, sessionmaker
 
 # ---------------------------------------------------------------------------
 # Database setup
@@ -272,20 +272,19 @@ def create_app() -> Flask:
 
     engine = create_engine("sqlite:///demo.db")
     Base.metadata.create_all(engine)
-    SessionLocal = sessionmaker(bind=engine)  # noqa: N806
+    session_factory = sessionmaker(bind=engine)
+    session = scoped_session(session_factory)
 
-    with SessionLocal() as session:
-        seed(session)
+    with session_factory() as seed_session:
+        seed(seed_session)
 
     admin = Admin(app, name="Opinionated Mixins", template_mode="bootstrap4")
-    admin.add_view(
-        AnnouncementAdmin(AnnouncementModel, SessionLocal(), name="Announcements"),
-    )
-    admin.add_view(FeedbackAdmin(FeedbackModel, SessionLocal(), name="Feedback"))
-    admin.add_view(TemplateAdmin(TemplateModel, SessionLocal(), name="Templates"))
-    admin.add_view(LeadAdmin(LeadModel, SessionLocal(), name="Leads"))
-    admin.add_view(PersonAdmin(PersonModel, SessionLocal(), name="Persons"))
-    admin.add_view(UserAdmin(UserModel, SessionLocal(), name="Users"))
+    admin.add_view(AnnouncementAdmin(AnnouncementModel, session, name="Announcements"))
+    admin.add_view(FeedbackAdmin(FeedbackModel, session, name="Feedback"))
+    admin.add_view(TemplateAdmin(TemplateModel, session, name="Templates"))
+    admin.add_view(LeadAdmin(LeadModel, session, name="Leads"))
+    admin.add_view(PersonAdmin(PersonModel, session, name="Persons"))
+    admin.add_view(UserAdmin(UserModel, session, name="Users"))
 
     return app
 

--- a/examples/flask_admin_sqlalchemy/app.py
+++ b/examples/flask_admin_sqlalchemy/app.py
@@ -1,0 +1,294 @@
+"""Flask-Admin example showcasing all opinionated-mixins with SQLAlchemy.
+
+Run:
+    pip install flask flask-admin sqlalchemy opinionated-mixins
+    python app.py
+
+Then visit http://localhost:5000/admin/
+"""
+
+from __future__ import annotations
+
+from flask import Flask
+from flask_admin import Admin
+from flask_admin.contrib.sqla import ModelView
+from opinionated_mixins.contrib.sqlalchemy import (
+    UUIDID,
+    Announcement,
+    CreatedAt,
+    Feedback,
+    IntegerID,
+    IsActive,
+    Lead,
+    Person,
+    Template,
+    UpdatedAt,
+    User,
+)
+from opinionated_mixins.enums import (
+    AnnouncementCategory,
+    FeedbackCategory,
+    FeedbackStatus,
+    LeadRating,
+    LeadSource,
+    LeadStatus,
+    TemplateFormat,
+    TemplateType,
+)
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+# ---------------------------------------------------------------------------
+# Database setup
+# ---------------------------------------------------------------------------
+
+
+class Base(DeclarativeBase):
+    """Shared declarative base for all models."""
+
+
+class AnnouncementModel(IntegerID, CreatedAt, IsActive, Announcement, Base):
+    """Announcement with auto-increment ID, timestamp, and soft-delete."""
+
+    __tablename__ = "announcements"
+
+
+class FeedbackModel(IntegerID, CreatedAt, UpdatedAt, Feedback, Base):
+    """Feedback with auto-increment ID and both timestamps."""
+
+    __tablename__ = "feedbacks"
+
+
+class TemplateModel(IntegerID, CreatedAt, UpdatedAt, Template, Base):
+    """Template with auto-increment ID and both timestamps."""
+
+    __tablename__ = "templates"
+
+
+class LeadModel(IntegerID, CreatedAt, UpdatedAt, Lead, Base):
+    """Lead with auto-increment ID and both timestamps.
+
+    Note: Lead mixin already includes its own ``is_active`` field,
+    so the separate ``IsActive`` mixin is not needed here.
+    """
+
+    __tablename__ = "leads"
+
+
+class PersonModel(IntegerID, Person, Base):
+    """Person with auto-increment ID."""
+
+    __tablename__ = "persons"
+
+
+class UserModel(UUIDID, CreatedAt, User, Base):
+    """User with UUID primary key and creation timestamp."""
+
+    __tablename__ = "users"
+
+
+# ---------------------------------------------------------------------------
+# Flask-Admin views
+# ---------------------------------------------------------------------------
+
+
+class AnnouncementAdmin(ModelView):
+    """Admin view for announcements."""
+
+    column_list = [
+        "id",
+        "title",
+        "category",
+        "is_active",
+        "created_at",
+    ]
+    column_searchable_list = ["title", "content"]
+    column_filters = ["category", "is_active", "created_at"]
+    form_choices = {
+        "category": [(c.value, c.name) for c in AnnouncementCategory],
+    }
+
+
+class FeedbackAdmin(ModelView):
+    """Admin view for feedback submissions."""
+
+    column_list = [
+        "id",
+        "subject",
+        "category",
+        "status",
+        "created_at",
+        "updated_at",
+    ]
+    column_searchable_list = ["subject", "content"]
+    column_filters = ["category", "status"]
+    form_choices = {
+        "category": [(c.value, c.name) for c in FeedbackCategory],
+        "status": [(s.value, s.name) for s in FeedbackStatus],
+    }
+
+
+class TemplateAdmin(ModelView):
+    """Admin view for templates."""
+
+    column_list = [
+        "id",
+        "name",
+        "format",
+        "type",
+        "created_at",
+        "updated_at",
+    ]
+    column_searchable_list = ["name", "content"]
+    column_filters = ["format", "type"]
+    form_choices = {
+        "format": [(f.value, f.name) for f in TemplateFormat],
+        "type": [(t.value, t.name) for t in TemplateType],
+    }
+
+
+class LeadAdmin(ModelView):
+    """Admin view for leads."""
+
+    column_list = [
+        "id",
+        "title",
+        "company_name",
+        "status",
+        "source",
+        "rating",
+        "opportunity_amount",
+        "is_active",
+        "created_at",
+    ]
+    column_searchable_list = ["title", "company_name"]
+    column_filters = ["status", "source", "rating", "is_active"]
+    form_choices = {
+        "status": [(s.value, s.name) for s in LeadStatus],
+        "source": [(s.value, s.name) for s in LeadSource],
+        "rating": [(r.value, r.name) for r in LeadRating],
+    }
+
+
+class PersonAdmin(ModelView):
+    """Admin view for persons."""
+
+    column_list = [
+        "id",
+        "first_name",
+        "last_name",
+        "email",
+        "phone_number",
+        "city",
+        "country",
+    ]
+    column_searchable_list = ["first_name", "last_name", "email"]
+    column_filters = ["country", "city"]
+
+
+class UserAdmin(ModelView):
+    """Admin view for users."""
+
+    column_list = [
+        "id",
+        "username",
+        "email",
+        "date_email_verified",
+        "created_at",
+    ]
+    column_searchable_list = ["username", "email"]
+    column_filters = ["date_email_verified", "created_at"]
+    form_excluded_columns = ["hashed_password"]
+
+
+# ---------------------------------------------------------------------------
+# Seed data
+# ---------------------------------------------------------------------------
+
+
+def seed(session: Session) -> None:
+    """Insert sample records so the admin UI isn't empty on first launch."""
+    if session.query(AnnouncementModel).count():
+        return
+
+    session.add_all(
+        [
+            AnnouncementModel(
+                title="Scheduled maintenance",
+                content="Systems will be down Saturday 02:00-04:00 UTC.",
+                category=AnnouncementCategory.MAINTENANCE,
+            ),
+            AnnouncementModel(
+                title="New feature: Dark mode",
+                content="Dark mode is now available in settings.",
+                category=AnnouncementCategory.UPDATE,
+            ),
+            FeedbackModel(
+                subject="Login page slow",
+                content="Takes 5+ seconds to load on mobile.",
+                category=FeedbackCategory.BUG,
+                status=FeedbackStatus.PENDING,
+            ),
+            TemplateModel(
+                name="Welcome email",
+                content="Hi {{ name }}, welcome aboard!",
+                format=TemplateFormat.HTML,
+                type=TemplateType.EMAIL,
+            ),
+            LeadModel(
+                title="Mr.",
+                company_name="Acme Corp",
+                status=LeadStatus.IN_PROCESS,
+                source=LeadSource.CALL,
+                rating=LeadRating.HOT,
+            ),
+            PersonModel(
+                first_name="Ada",
+                last_name="Lovelace",
+                email="ada@example.com",
+                city="London",
+                country="GB",
+            ),
+            UserModel(
+                username="admin",
+                hashed_password="pbkdf2:sha256:placeholder",
+                email="admin@example.com",
+            ),
+        ],
+    )
+    session.commit()
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "dev-only-secret-key"
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///demo.db"
+
+    engine = create_engine("sqlite:///demo.db")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)  # noqa: N806
+
+    with SessionLocal() as session:
+        seed(session)
+
+    admin = Admin(app, name="Opinionated Mixins", template_mode="bootstrap4")
+    admin.add_view(
+        AnnouncementAdmin(AnnouncementModel, SessionLocal(), name="Announcements"),
+    )
+    admin.add_view(FeedbackAdmin(FeedbackModel, SessionLocal(), name="Feedback"))
+    admin.add_view(TemplateAdmin(TemplateModel, SessionLocal(), name="Templates"))
+    admin.add_view(LeadAdmin(LeadModel, SessionLocal(), name="Leads"))
+    admin.add_view(PersonAdmin(PersonModel, SessionLocal(), name="Persons"))
+    admin.add_view(UserAdmin(UserModel, SessionLocal(), name="Users"))
+
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(debug=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,16 +72,20 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
+  "ANN001",  # Missing type annotation for function argument (fixtures)
+  "ANN202",  # Missing return type for private function (fixtures)
   "D101",    # Missing docstring in public class
   "D102",    # Missing docstring in public method
   "D103",    # Missing docstring in public function
+  "DTZ001",  # datetime without tzinfo (test fixtures)
+  "DTZ011",  # datetime.date.today() used (test fixtures)
+  "PLC0415", # Import not at top-level (intentional in test methods)
+  "PLR2004", # Magic value used in comparison (expected in tests)
+  "PT018",   # Compound assertion (intentional for clear error messages)
+  "RUF012",  # Mutable class attribute without ClassVar (test model meta)
   "S101",    # Use of assert (expected in tests)
   "S105",    # Possible hardcoded password (test fixtures)
   "S106",    # Possible hardcoded password in argument (test fixtures)
-  "PLR2004", # Magic value used in comparison (expected in tests)
-  "PT018",   # Compound assertion (intentional for clear error messages)
-  "PLC0415", # Import not at top-level (intentional in test methods)
-  "DTZ001",  # datetime without tzinfo (test fixtures)
 ]
 "src/opinionated_mixins/contrib/sqlmodel/*.py" = [
   "PLC0414", # Import alias does not rename (intentional re-exports)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,16 @@ ignore = [
   "S105",    # Possible hardcoded password (test fixtures)
   "S106",    # Possible hardcoded password in argument (test fixtures)
 ]
+"examples/**/*.py" = [
+  "D101",    # Missing docstring in public class (model definitions)
+  "D106",    # Missing docstring in public nested class (Meta)
+  "INP001",  # Implicit namespace package (examples aren't packages)
+  "PLC0415", # Import not at top-level (conditional imports like mongomock)
+  "RUF012",  # Mutable class attribute without ClassVar (model columns)
+  "S105",    # Possible hardcoded password (demo data)
+  "S106",    # Possible hardcoded password in argument (demo data)
+  "T201",    # print() usage (example scripts)
+]
 "src/opinionated_mixins/contrib/sqlmodel/*.py" = [
   "PLC0414", # Import alias does not rename (intentional re-exports)
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dev = [
   "sqlalchemy==2.0.49",
   "mongoengine==0.29.3",
   "odmantic==1.1.0",
+  "mongomock>=4.3.0",
+  "mongomock-motor>=0.0.32",
+  "testcontainers[mongodb]>=4.10.0",
+  "pytest-asyncio>=0.26.0",
 ]
 types = [
   "mypy>=1.20.1",
@@ -128,3 +132,10 @@ tests = ["tests", "*/opinionated-mixins/tests"]
 
 [tool.coverage.report]
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
+
+
+[tool.pytest.ini_options]
+markers = [
+    "mongo: requires real MongoDB via testcontainers (skipped by default)",
+]
+asyncio_mode = "auto"

--- a/tests/mongoengine/conftest.py
+++ b/tests/mongoengine/conftest.py
@@ -1,0 +1,16 @@
+"""Shared fixtures for MongoEngine integration tests."""
+
+import mongoengine
+import mongomock
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mongomock_connection():
+    """Connect MongoEngine to mongomock for every test."""
+    conn = mongoengine.connect(
+        "testdb",
+        mongo_client_class=mongomock.MongoClient,
+    )
+    yield conn
+    mongoengine.disconnect_all()

--- a/tests/mongoengine/conftest.py
+++ b/tests/mongoengine/conftest.py
@@ -8,11 +8,11 @@ import pytest
 @pytest.fixture(autouse=True)
 def _mongomock_connection():
     """Connect MongoEngine to mongomock for every test."""
-    conn = mongoengine.connect(
+    client = mongoengine.connect(
         "testdb",
         mongo_client_class=mongomock.MongoClient,
     )
-    yield conn
+    yield client
     # Drop all collections to prevent data leaking between tests
-    conn.drop_database("testdb")
+    client.drop_database("testdb")
     mongoengine.disconnect_all()

--- a/tests/mongoengine/conftest.py
+++ b/tests/mongoengine/conftest.py
@@ -13,4 +13,6 @@ def _mongomock_connection():
         mongo_client_class=mongomock.MongoClient,
     )
     yield conn
+    # Drop all collections to prevent data leaking between tests
+    conn.drop_database("testdb")
     mongoengine.disconnect_all()

--- a/tests/mongoengine/test_announcement_integration.py
+++ b/tests/mongoengine/test_announcement_integration.py
@@ -1,0 +1,47 @@
+"""Integration tests for MongoEngine Announcement mixin."""
+
+from mongoengine import Document
+
+from opinionated_mixins.contrib.mongoengine import Announcement
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+class MyAnnouncement(Announcement, Document):
+    """Test model composing Announcement with Document."""
+
+    meta = {"collection": "test_announcements"}
+
+
+class TestAnnouncementIntegration:
+    """Test Announcement mixin composition, instantiation, and roundtrip."""
+
+    def test_create_with_defaults(self) -> None:
+        obj = MyAnnouncement(title="Test", content="Hello world")
+        obj.save()
+        loaded = MyAnnouncement.objects.first()
+        assert loaded is not None
+        assert loaded.title == "Test"
+        assert loaded.content == "Hello world"
+        assert loaded.category == AnnouncementCategory.GENERAL.value
+
+    def test_create_with_explicit_category(self) -> None:
+        obj = MyAnnouncement(
+            title="Downtime",
+            content="Scheduled maintenance",
+            category=AnnouncementCategory.MAINTENANCE.value,
+        )
+        obj.save()
+        loaded = MyAnnouncement.objects.first()
+        assert loaded.category == AnnouncementCategory.MAINTENANCE.value
+
+    def test_roundtrip_preserves_all_fields(self) -> None:
+        obj = MyAnnouncement(
+            title="Alert",
+            content="System update",
+            category=AnnouncementCategory.WARNING.value,
+        )
+        obj.save()
+        loaded = MyAnnouncement.objects.first()
+        assert loaded.title == "Alert"
+        assert loaded.content == "System update"
+        assert loaded.category == AnnouncementCategory.WARNING.value

--- a/tests/mongoengine/test_announcement_integration.py
+++ b/tests/mongoengine/test_announcement_integration.py
@@ -1,7 +1,6 @@
 """Integration tests for MongoEngine Announcement mixin."""
 
 from mongoengine import Document
-
 from opinionated_mixins.contrib.mongoengine import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
 

--- a/tests/mongoengine/test_created_at_integration.py
+++ b/tests/mongoengine/test_created_at_integration.py
@@ -30,8 +30,7 @@ class TestCreatedAtIntegration:
         loaded = MyModel.objects.first()
         now = datetime.datetime.now(datetime.timezone.utc)
         # created_at should be within last 5 seconds
-        utc = datetime.timezone.utc
-        delta = now - loaded.created_at.replace(tzinfo=utc)
+        delta = now - loaded.created_at.replace(tzinfo=datetime.timezone.utc)
         assert delta.total_seconds() < 5
 
     def test_created_at_survives_roundtrip(self) -> None:

--- a/tests/mongoengine/test_created_at_integration.py
+++ b/tests/mongoengine/test_created_at_integration.py
@@ -3,7 +3,6 @@
 import datetime
 
 from mongoengine import Document, StringField
-
 from opinionated_mixins.contrib.mongoengine import CreatedAt
 
 
@@ -31,11 +30,14 @@ class TestCreatedAtIntegration:
         loaded = MyModel.objects.first()
         now = datetime.datetime.now(datetime.timezone.utc)
         # created_at should be within last 5 seconds
-        assert (now - loaded.created_at.replace(tzinfo=datetime.timezone.utc)).total_seconds() < 5
+        utc = datetime.timezone.utc
+        delta = now - loaded.created_at.replace(tzinfo=utc)
+        assert delta.total_seconds() < 5
 
     def test_created_at_survives_roundtrip(self) -> None:
         obj = MyModel(name="test")
         obj.save()
         loaded = MyModel.objects.first()
         # mongomock truncates microseconds; compare up to millisecond precision
-        assert abs((loaded.created_at - obj.created_at.replace(tzinfo=None)).total_seconds()) < 0.01
+        diff = loaded.created_at - obj.created_at.replace(tzinfo=None)
+        assert abs(diff.total_seconds()) < 0.01

--- a/tests/mongoengine/test_created_at_integration.py
+++ b/tests/mongoengine/test_created_at_integration.py
@@ -1,0 +1,41 @@
+"""Integration tests for MongoEngine CreatedAt mixin."""
+
+import datetime
+
+from mongoengine import Document, StringField
+
+from opinionated_mixins.contrib.mongoengine import CreatedAt
+
+
+class MyModel(CreatedAt, Document):
+    """Test model composing CreatedAt with Document."""
+
+    meta = {"collection": "test_created_at"}
+    name = StringField(required=True)
+
+
+class TestCreatedAtIntegration:
+    """Test CreatedAt mixin composition, instantiation, and roundtrip."""
+
+    def test_created_at_set_on_save(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        loaded = MyModel.objects.first()
+        assert loaded is not None
+        assert loaded.created_at is not None
+        assert isinstance(loaded.created_at, datetime.datetime)
+
+    def test_created_at_is_utc(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        loaded = MyModel.objects.first()
+        now = datetime.datetime.now(datetime.timezone.utc)
+        # created_at should be within last 5 seconds
+        assert (now - loaded.created_at.replace(tzinfo=datetime.timezone.utc)).total_seconds() < 5
+
+    def test_created_at_survives_roundtrip(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        loaded = MyModel.objects.first()
+        # mongomock truncates microseconds; compare up to millisecond precision
+        assert abs((loaded.created_at - obj.created_at.replace(tzinfo=None)).total_seconds()) < 0.01

--- a/tests/mongoengine/test_feedback_integration.py
+++ b/tests/mongoengine/test_feedback_integration.py
@@ -1,7 +1,6 @@
 """Integration tests for MongoEngine Feedback mixin."""
 
 from mongoengine import Document
-
 from opinionated_mixins.contrib.mongoengine import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 

--- a/tests/mongoengine/test_feedback_integration.py
+++ b/tests/mongoengine/test_feedback_integration.py
@@ -1,0 +1,52 @@
+"""Integration tests for MongoEngine Feedback mixin."""
+
+from mongoengine import Document
+
+from opinionated_mixins.contrib.mongoengine import Feedback
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+
+class MyFeedback(Feedback, Document):
+    """Test model composing Feedback with Document."""
+
+    meta = {"collection": "test_feedbacks"}
+
+
+class TestFeedbackIntegration:
+    """Test Feedback mixin composition, instantiation, and roundtrip."""
+
+    def test_create_with_defaults(self) -> None:
+        obj = MyFeedback(subject="Bug report", content="Something broke")
+        obj.save()
+        loaded = MyFeedback.objects.first()
+        assert loaded is not None
+        assert loaded.subject == "Bug report"
+        assert loaded.content == "Something broke"
+        assert loaded.category == FeedbackCategory.OTHER.value
+        assert loaded.status == FeedbackStatus.PENDING.value
+
+    def test_create_with_explicit_values(self) -> None:
+        obj = MyFeedback(
+            subject="Feature request",
+            content="Add dark mode",
+            category=FeedbackCategory.FEATURE.value,
+            status=FeedbackStatus.REVIEWED.value,
+        )
+        obj.save()
+        loaded = MyFeedback.objects.first()
+        assert loaded.category == FeedbackCategory.FEATURE.value
+        assert loaded.status == FeedbackStatus.REVIEWED.value
+
+    def test_roundtrip_preserves_all_fields(self) -> None:
+        obj = MyFeedback(
+            subject="Improvement",
+            content="Faster loading",
+            category=FeedbackCategory.IMPROVEMENT.value,
+            status=FeedbackStatus.RESOLVED.value,
+        )
+        obj.save()
+        loaded = MyFeedback.objects.first()
+        assert loaded.subject == "Improvement"
+        assert loaded.content == "Faster loading"
+        assert loaded.category == FeedbackCategory.IMPROVEMENT.value
+        assert loaded.status == FeedbackStatus.RESOLVED.value

--- a/tests/mongoengine/test_is_active_integration.py
+++ b/tests/mongoengine/test_is_active_integration.py
@@ -1,0 +1,37 @@
+"""Integration tests for MongoEngine IsActive mixin."""
+
+from mongoengine import Document, StringField
+
+from opinionated_mixins.contrib.mongoengine import IsActive
+
+
+class MyModel(IsActive, Document):
+    """Test model composing IsActive with Document."""
+
+    meta = {"collection": "test_is_active"}
+    name = StringField(required=True)
+
+
+class TestIsActiveIntegration:
+    """Test IsActive mixin composition, instantiation, and roundtrip."""
+
+    def test_defaults_true(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        loaded = MyModel.objects.first()
+        assert loaded is not None
+        assert loaded.is_active is True
+
+    def test_toggle_to_false(self) -> None:
+        obj = MyModel(name="test", is_active=False)
+        obj.save()
+        loaded = MyModel.objects.first()
+        assert loaded.is_active is False
+
+    def test_update_persists(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        obj.is_active = False
+        obj.save()
+        loaded = MyModel.objects.first()
+        assert loaded.is_active is False

--- a/tests/mongoengine/test_is_active_integration.py
+++ b/tests/mongoengine/test_is_active_integration.py
@@ -1,7 +1,6 @@
 """Integration tests for MongoEngine IsActive mixin."""
 
 from mongoengine import Document, StringField
-
 from opinionated_mixins.contrib.mongoengine import IsActive
 
 

--- a/tests/mongoengine/test_lead_integration.py
+++ b/tests/mongoengine/test_lead_integration.py
@@ -1,0 +1,78 @@
+"""Integration tests for MongoEngine Lead mixin."""
+
+import datetime
+from decimal import Decimal
+
+from mongoengine import Document
+
+from opinionated_mixins.contrib.mongoengine import Lead
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+
+class MyLead(Lead, Document):
+    """Test model composing Lead with Document."""
+
+    meta = {"collection": "test_leads"}
+
+
+class TestLeadIntegration:
+    """Test Lead mixin composition, instantiation, and roundtrip."""
+
+    def test_create_with_defaults(self) -> None:
+        obj = MyLead()
+        obj.save()
+        loaded = MyLead.objects.first()
+        assert loaded is not None
+        assert loaded.probability == 0
+        assert loaded.is_active is True
+        assert loaded.title is None
+        assert loaded.status is None
+        assert loaded.source is None
+        assert loaded.rating is None
+
+    def test_create_with_all_fields(self) -> None:
+        today = datetime.date.today()
+        obj = MyLead(
+            title="Big Deal",
+            salutation="Mr",
+            job_title="CTO",
+            company_name="Acme Corp",
+            website="https://acme.example.com",
+            linkedin_url="https://linkedin.com/in/johndoe",
+            status=LeadStatus.IN_PROCESS.value,
+            source=LeadSource.EMAIL.value,
+            industry="Technology",
+            rating=LeadRating.HOT.value,
+            opportunity_amount=Decimal("50000.00"),
+            currency="USD",
+            probability=75,
+            close_date=today,
+            last_contacted=today,
+            next_follow_up=today,
+            description="A big opportunity",
+            is_active=True,
+        )
+        obj.save()
+        loaded = MyLead.objects.first()
+        assert loaded.title == "Big Deal"
+        assert loaded.salutation == "Mr"
+        assert loaded.job_title == "CTO"
+        assert loaded.company_name == "Acme Corp"
+        assert loaded.status == LeadStatus.IN_PROCESS.value
+        assert loaded.source == LeadSource.EMAIL.value
+        assert loaded.rating == LeadRating.HOT.value
+        assert loaded.probability == 75
+        assert loaded.currency == "USD"
+        assert loaded.description == "A big opportunity"
+
+    def test_enum_fields_roundtrip(self) -> None:
+        obj = MyLead(
+            status=LeadStatus.CONVERTED.value,
+            source=LeadSource.PARTNER.value,
+            rating=LeadRating.COLD.value,
+        )
+        obj.save()
+        loaded = MyLead.objects.first()
+        assert loaded.status == LeadStatus.CONVERTED.value
+        assert loaded.source == LeadSource.PARTNER.value
+        assert loaded.rating == LeadRating.COLD.value

--- a/tests/mongoengine/test_lead_integration.py
+++ b/tests/mongoengine/test_lead_integration.py
@@ -4,7 +4,6 @@ import datetime
 from decimal import Decimal
 
 from mongoengine import Document
-
 from opinionated_mixins.contrib.mongoengine import Lead
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
 

--- a/tests/mongoengine/test_person_integration.py
+++ b/tests/mongoengine/test_person_integration.py
@@ -1,0 +1,67 @@
+"""Integration tests for MongoEngine Person mixin."""
+
+import datetime
+
+from mongoengine import Document
+
+from opinionated_mixins.contrib.mongoengine import Person
+
+
+class MyPerson(Person, Document):
+    """Test model composing Person with Document."""
+
+    meta = {"collection": "test_persons"}
+
+
+class TestPersonIntegration:
+    """Test Person mixin composition, instantiation, and roundtrip."""
+
+    def test_create_with_required_fields(self) -> None:
+        obj = MyPerson(first_name="Alice", last_name="Smith")
+        obj.save()
+        loaded = MyPerson.objects.first()
+        assert loaded is not None
+        assert loaded.first_name == "Alice"
+        assert loaded.last_name == "Smith"
+        assert loaded.middle_name is None
+        assert loaded.phone_number is None
+        assert loaded.email is None
+
+    def test_create_with_all_fields(self) -> None:
+        dob = datetime.date(1990, 1, 15)
+        obj = MyPerson(
+            first_name="Bob",
+            last_name="Jones",
+            middle_name="M",
+            phone_number="+1234567890",
+            email="bob@example.com",
+            street_address="123 Main St",
+            postal_code="12345",
+            city="Springfield",
+            country="US",
+            date_of_birth=dob,
+            bio="A test person",
+        )
+        obj.save()
+        loaded = MyPerson.objects.first()
+        assert loaded.first_name == "Bob"
+        assert loaded.middle_name == "M"
+        assert loaded.phone_number == "+1234567890"
+        assert loaded.email == "bob@example.com"
+        assert loaded.street_address == "123 Main St"
+        assert loaded.postal_code == "12345"
+        assert loaded.city == "Springfield"
+        assert loaded.country == "US"
+        assert loaded.date_of_birth == dob
+        assert loaded.bio == "A test person"
+
+    def test_optional_fields_default_none(self) -> None:
+        obj = MyPerson(first_name="C", last_name="D")
+        obj.save()
+        loaded = MyPerson.objects.first()
+        assert loaded.street_address is None
+        assert loaded.postal_code is None
+        assert loaded.city is None
+        assert loaded.country is None
+        assert loaded.date_of_birth is None
+        assert loaded.bio is None

--- a/tests/mongoengine/test_person_integration.py
+++ b/tests/mongoengine/test_person_integration.py
@@ -3,7 +3,6 @@
 import datetime
 
 from mongoengine import Document
-
 from opinionated_mixins.contrib.mongoengine import Person
 
 

--- a/tests/mongoengine/test_template_integration.py
+++ b/tests/mongoengine/test_template_integration.py
@@ -1,0 +1,52 @@
+"""Integration tests for MongoEngine Template mixin."""
+
+from mongoengine import Document
+
+from opinionated_mixins.contrib.mongoengine import Template
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+
+class MyTemplate(Template, Document):
+    """Test model composing Template with Document."""
+
+    meta = {"collection": "test_templates"}
+
+
+class TestTemplateIntegration:
+    """Test Template mixin composition, instantiation, and roundtrip."""
+
+    def test_create_with_defaults(self) -> None:
+        obj = MyTemplate(name="Welcome", content="Hello {{name}}")
+        obj.save()
+        loaded = MyTemplate.objects.first()
+        assert loaded is not None
+        assert loaded.name == "Welcome"
+        assert loaded.content == "Hello {{name}}"
+        assert loaded.format == TemplateFormat.PLAIN.value
+        assert loaded.type == TemplateType.OTHER.value
+
+    def test_create_with_explicit_values(self) -> None:
+        obj = MyTemplate(
+            name="Newsletter",
+            content="<h1>News</h1>",
+            format=TemplateFormat.HTML.value,
+            type=TemplateType.EMAIL.value,
+        )
+        obj.save()
+        loaded = MyTemplate.objects.first()
+        assert loaded.format == TemplateFormat.HTML.value
+        assert loaded.type == TemplateType.EMAIL.value
+
+    def test_roundtrip_preserves_all_fields(self) -> None:
+        obj = MyTemplate(
+            name="Alert",
+            content="# Alert",
+            format=TemplateFormat.MARKDOWN.value,
+            type=TemplateType.PUSH.value,
+        )
+        obj.save()
+        loaded = MyTemplate.objects.first()
+        assert loaded.name == "Alert"
+        assert loaded.content == "# Alert"
+        assert loaded.format == TemplateFormat.MARKDOWN.value
+        assert loaded.type == TemplateType.PUSH.value

--- a/tests/mongoengine/test_template_integration.py
+++ b/tests/mongoengine/test_template_integration.py
@@ -1,7 +1,6 @@
 """Integration tests for MongoEngine Template mixin."""
 
 from mongoengine import Document
-
 from opinionated_mixins.contrib.mongoengine import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType
 

--- a/tests/mongoengine/test_updated_at_integration.py
+++ b/tests/mongoengine/test_updated_at_integration.py
@@ -29,8 +29,7 @@ class TestUpdatedAtIntegration:
         obj.save()
         loaded = MyModel.objects.first()
         now = datetime.datetime.now(datetime.timezone.utc)
-        utc = datetime.timezone.utc
-        delta = now - loaded.updated_at.replace(tzinfo=utc)
+        delta = now - loaded.updated_at.replace(tzinfo=datetime.timezone.utc)
         assert delta.total_seconds() < 5
 
     def test_updated_at_survives_roundtrip(self) -> None:
@@ -40,3 +39,20 @@ class TestUpdatedAtIntegration:
         # mongomock truncates microseconds; compare up to millisecond precision
         diff = loaded.updated_at - obj.updated_at.replace(tzinfo=None)
         assert abs(diff.total_seconds()) < 0.01
+
+    def test_updated_at_can_be_manually_refreshed(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        first_loaded = MyModel.objects.first()
+        first_ts = first_loaded.updated_at
+        # Mixin provides the field; consumer is responsible for updating it
+        import time
+
+        time.sleep(0.01)
+        obj.updated_at = datetime.datetime.now(datetime.timezone.utc)
+        obj.name = "changed"
+        obj.save()
+        loaded = MyModel.objects.first()
+        assert loaded.name == "changed"
+        # Both timestamps come from mongomock with same truncation
+        assert loaded.updated_at >= first_ts

--- a/tests/mongoengine/test_updated_at_integration.py
+++ b/tests/mongoengine/test_updated_at_integration.py
@@ -1,0 +1,40 @@
+"""Integration tests for MongoEngine UpdatedAt mixin."""
+
+import datetime
+
+from mongoengine import Document, StringField
+
+from opinionated_mixins.contrib.mongoengine import UpdatedAt
+
+
+class MyModel(UpdatedAt, Document):
+    """Test model composing UpdatedAt with Document."""
+
+    meta = {"collection": "test_updated_at"}
+    name = StringField(required=True)
+
+
+class TestUpdatedAtIntegration:
+    """Test UpdatedAt mixin composition, instantiation, and roundtrip."""
+
+    def test_updated_at_set_on_save(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        loaded = MyModel.objects.first()
+        assert loaded is not None
+        assert loaded.updated_at is not None
+        assert isinstance(loaded.updated_at, datetime.datetime)
+
+    def test_updated_at_is_utc(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        loaded = MyModel.objects.first()
+        now = datetime.datetime.now(datetime.timezone.utc)
+        assert (now - loaded.updated_at.replace(tzinfo=datetime.timezone.utc)).total_seconds() < 5
+
+    def test_updated_at_survives_roundtrip(self) -> None:
+        obj = MyModel(name="test")
+        obj.save()
+        loaded = MyModel.objects.first()
+        # mongomock truncates microseconds; compare up to millisecond precision
+        assert abs((loaded.updated_at - obj.updated_at.replace(tzinfo=None)).total_seconds()) < 0.01

--- a/tests/mongoengine/test_updated_at_integration.py
+++ b/tests/mongoengine/test_updated_at_integration.py
@@ -3,7 +3,6 @@
 import datetime
 
 from mongoengine import Document, StringField
-
 from opinionated_mixins.contrib.mongoengine import UpdatedAt
 
 
@@ -30,11 +29,14 @@ class TestUpdatedAtIntegration:
         obj.save()
         loaded = MyModel.objects.first()
         now = datetime.datetime.now(datetime.timezone.utc)
-        assert (now - loaded.updated_at.replace(tzinfo=datetime.timezone.utc)).total_seconds() < 5
+        utc = datetime.timezone.utc
+        delta = now - loaded.updated_at.replace(tzinfo=utc)
+        assert delta.total_seconds() < 5
 
     def test_updated_at_survives_roundtrip(self) -> None:
         obj = MyModel(name="test")
         obj.save()
         loaded = MyModel.objects.first()
         # mongomock truncates microseconds; compare up to millisecond precision
-        assert abs((loaded.updated_at - obj.updated_at.replace(tzinfo=None)).total_seconds()) < 0.01
+        diff = loaded.updated_at - obj.updated_at.replace(tzinfo=None)
+        assert abs(diff.total_seconds()) < 0.01

--- a/tests/mongoengine/test_user_integration.py
+++ b/tests/mongoengine/test_user_integration.py
@@ -1,0 +1,52 @@
+"""Integration tests for MongoEngine User mixin."""
+
+import datetime
+
+from mongoengine import Document
+
+from opinionated_mixins.contrib.mongoengine import User
+
+
+class MyUser(User, Document):
+    """Test model composing User with Document."""
+
+    meta = {"collection": "test_users"}
+
+
+class TestUserIntegration:
+    """Test User mixin composition, instantiation, and roundtrip."""
+
+    def test_create_with_required_fields(self) -> None:
+        obj = MyUser(username="alice", hashed_password="hashed123")
+        obj.save()
+        loaded = MyUser.objects.first()
+        assert loaded is not None
+        assert loaded.username == "alice"
+        assert loaded.hashed_password == "hashed123"
+        assert loaded.email is None
+        assert loaded.date_email_verified is None
+
+    def test_create_with_all_fields(self) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        obj = MyUser(
+            username="bob",
+            hashed_password="hashed456",
+            email="bob@example.com",
+            date_email_verified=now,
+        )
+        obj.save()
+        loaded = MyUser.objects.first()
+        assert loaded.email == "bob@example.com"
+        assert loaded.date_email_verified is not None
+
+    def test_roundtrip_preserves_all_fields(self) -> None:
+        obj = MyUser(
+            username="charlie",
+            hashed_password="hashed789",
+            email="charlie@example.com",
+        )
+        obj.save()
+        loaded = MyUser.objects.first()
+        assert loaded.username == "charlie"
+        assert loaded.hashed_password == "hashed789"
+        assert loaded.email == "charlie@example.com"

--- a/tests/mongoengine/test_user_integration.py
+++ b/tests/mongoengine/test_user_integration.py
@@ -3,7 +3,6 @@
 import datetime
 
 from mongoengine import Document
-
 from opinionated_mixins.contrib.mongoengine import User
 
 

--- a/tests/odmantic/conftest.py
+++ b/tests/odmantic/conftest.py
@@ -5,9 +5,8 @@ from mongomock_motor import AsyncMongoMockClient
 from odmantic import AIOEngine
 
 
-@pytest.fixture()
-async def mock_engine():
+@pytest.fixture
+async def mock_engine() -> AIOEngine:
     """AIOEngine backed by mongomock-motor."""
     client = AsyncMongoMockClient()
-    engine = AIOEngine(client=client, database="testdb")
-    yield engine
+    return AIOEngine(client=client, database="testdb")

--- a/tests/odmantic/conftest.py
+++ b/tests/odmantic/conftest.py
@@ -1,0 +1,13 @@
+"""Shared fixtures for ODMantic integration tests."""
+
+import pytest
+from mongomock_motor import AsyncMongoMockClient
+from odmantic import AIOEngine
+
+
+@pytest.fixture()
+async def mock_engine():
+    """AIOEngine backed by mongomock-motor."""
+    client = AsyncMongoMockClient()
+    engine = AIOEngine(client=client, database="testdb")
+    yield engine

--- a/tests/odmantic/test_announcement_integration.py
+++ b/tests/odmantic/test_announcement_integration.py
@@ -2,10 +2,8 @@
 
 import pytest
 from odmantic import Model
-
 from opinionated_mixins.contrib.odmantic import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "

--- a/tests/odmantic/test_announcement_integration.py
+++ b/tests/odmantic/test_announcement_integration.py
@@ -1,0 +1,55 @@
+"""Integration tests for ODMantic Announcement mixin."""
+
+import pytest
+from odmantic import Model
+
+from opinionated_mixins.contrib.odmantic import Announcement
+from opinionated_mixins.enums import AnnouncementCategory
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyAnnouncement(Announcement, Model):
+    """Test model composing Announcement with Model."""
+
+    model_config = {"collection": "test_announcements"}
+
+
+class TestAnnouncementIntegration:
+    """Test Announcement mixin composition, instantiation, and roundtrip."""
+
+    async def test_create_with_defaults(self, mock_engine) -> None:
+        obj = MyAnnouncement(title="Test", content="Hello world")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyAnnouncement)
+        assert loaded is not None
+        assert loaded.title == "Test"
+        assert loaded.content == "Hello world"
+        assert loaded.category == AnnouncementCategory.GENERAL
+
+    async def test_create_with_explicit_category(self, mock_engine) -> None:
+        obj = MyAnnouncement(
+            title="Downtime",
+            content="Scheduled maintenance",
+            category=AnnouncementCategory.MAINTENANCE,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyAnnouncement)
+        assert loaded.category == AnnouncementCategory.MAINTENANCE
+
+    async def test_roundtrip_preserves_all_fields(self, mock_engine) -> None:
+        obj = MyAnnouncement(
+            title="Alert",
+            content="System update",
+            category=AnnouncementCategory.WARNING,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyAnnouncement)
+        assert loaded.title == "Alert"
+        assert loaded.content == "System update"
+        assert loaded.category == AnnouncementCategory.WARNING

--- a/tests/odmantic/test_announcement_integration.py
+++ b/tests/odmantic/test_announcement_integration.py
@@ -9,7 +9,7 @@ from opinionated_mixins.enums import AnnouncementCategory
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_announcement_integration.py
+++ b/tests/odmantic/test_announcement_integration.py
@@ -4,8 +4,10 @@ import pytest
 from odmantic import Model
 from opinionated_mixins.contrib.odmantic import Announcement
 from opinionated_mixins.enums import AnnouncementCategory
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/tests/odmantic/test_created_at_integration.py
+++ b/tests/odmantic/test_created_at_integration.py
@@ -4,9 +4,7 @@ import datetime
 
 import pytest
 from odmantic import Field, Model
-
 from opinionated_mixins.contrib.odmantic import CreatedAt
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
@@ -38,7 +36,8 @@ class TestCreatedAtIntegration:
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(MyModel)
         now = datetime.datetime.now(datetime.timezone.utc)
-        delta = (now - loaded.created_at.replace(tzinfo=datetime.timezone.utc)).total_seconds()
+        utc = datetime.timezone.utc
+        delta = (now - loaded.created_at.replace(tzinfo=utc)).total_seconds()
         assert delta < 5
 
     async def test_created_at_survives_roundtrip(self, mock_engine) -> None:
@@ -46,4 +45,5 @@ class TestCreatedAtIntegration:
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(MyModel)
         # mongomock may truncate microseconds; compare up to millisecond precision
-        assert abs((loaded.created_at - obj.created_at.replace(tzinfo=None)).total_seconds()) < 0.01
+        diff = loaded.created_at - obj.created_at.replace(tzinfo=None)
+        assert abs(diff.total_seconds()) < 0.01

--- a/tests/odmantic/test_created_at_integration.py
+++ b/tests/odmantic/test_created_at_integration.py
@@ -5,8 +5,10 @@ import datetime
 import pytest
 from odmantic import Field, Model
 from opinionated_mixins.contrib.odmantic import CreatedAt
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/tests/odmantic/test_created_at_integration.py
+++ b/tests/odmantic/test_created_at_integration.py
@@ -10,7 +10,7 @@ from opinionated_mixins.contrib.odmantic import CreatedAt
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_created_at_integration.py
+++ b/tests/odmantic/test_created_at_integration.py
@@ -1,0 +1,49 @@
+"""Integration tests for ODMantic CreatedAt mixin."""
+
+import datetime
+
+import pytest
+from odmantic import Field, Model
+
+from opinionated_mixins.contrib.odmantic import CreatedAt
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyModel(CreatedAt, Model):
+    """Test model composing CreatedAt with Model."""
+
+    model_config = {"collection": "test_created_at"}
+    name: str = Field(...)
+
+
+class TestCreatedAtIntegration:
+    """Test CreatedAt mixin composition, instantiation, and roundtrip."""
+
+    async def test_created_at_set_on_save(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        assert loaded is not None
+        assert loaded.created_at is not None
+        assert isinstance(loaded.created_at, datetime.datetime)
+
+    async def test_created_at_is_recent(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        delta = (now - loaded.created_at.replace(tzinfo=datetime.timezone.utc)).total_seconds()
+        assert delta < 5
+
+    async def test_created_at_survives_roundtrip(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        # mongomock may truncate microseconds; compare up to millisecond precision
+        assert abs((loaded.created_at - obj.created_at.replace(tzinfo=None)).total_seconds()) < 0.01

--- a/tests/odmantic/test_feedback_integration.py
+++ b/tests/odmantic/test_feedback_integration.py
@@ -2,10 +2,8 @@
 
 import pytest
 from odmantic import Model
-
 from opinionated_mixins.contrib.odmantic import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "

--- a/tests/odmantic/test_feedback_integration.py
+++ b/tests/odmantic/test_feedback_integration.py
@@ -4,8 +4,10 @@ import pytest
 from odmantic import Model
 from opinionated_mixins.contrib.odmantic import Feedback
 from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/tests/odmantic/test_feedback_integration.py
+++ b/tests/odmantic/test_feedback_integration.py
@@ -9,7 +9,7 @@ from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_feedback_integration.py
+++ b/tests/odmantic/test_feedback_integration.py
@@ -1,0 +1,60 @@
+"""Integration tests for ODMantic Feedback mixin."""
+
+import pytest
+from odmantic import Model
+
+from opinionated_mixins.contrib.odmantic import Feedback
+from opinionated_mixins.enums import FeedbackCategory, FeedbackStatus
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyFeedback(Feedback, Model):
+    """Test model composing Feedback with Model."""
+
+    model_config = {"collection": "test_feedbacks"}
+
+
+class TestFeedbackIntegration:
+    """Test Feedback mixin composition, instantiation, and roundtrip."""
+
+    async def test_create_with_defaults(self, mock_engine) -> None:
+        obj = MyFeedback(subject="Bug report", content="Something broke")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyFeedback)
+        assert loaded is not None
+        assert loaded.subject == "Bug report"
+        assert loaded.content == "Something broke"
+        assert loaded.category == FeedbackCategory.OTHER
+        assert loaded.status == FeedbackStatus.PENDING
+
+    async def test_create_with_explicit_values(self, mock_engine) -> None:
+        obj = MyFeedback(
+            subject="Feature request",
+            content="Add dark mode",
+            category=FeedbackCategory.FEATURE,
+            status=FeedbackStatus.REVIEWED,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyFeedback)
+        assert loaded.category == FeedbackCategory.FEATURE
+        assert loaded.status == FeedbackStatus.REVIEWED
+
+    async def test_roundtrip_preserves_all_fields(self, mock_engine) -> None:
+        obj = MyFeedback(
+            subject="Improvement",
+            content="Faster loading",
+            category=FeedbackCategory.IMPROVEMENT,
+            status=FeedbackStatus.RESOLVED,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyFeedback)
+        assert loaded.subject == "Improvement"
+        assert loaded.content == "Faster loading"
+        assert loaded.category == FeedbackCategory.IMPROVEMENT
+        assert loaded.status == FeedbackStatus.RESOLVED

--- a/tests/odmantic/test_is_active_integration.py
+++ b/tests/odmantic/test_is_active_integration.py
@@ -2,9 +2,7 @@
 
 import pytest
 from odmantic import Field, Model
-
 from opinionated_mixins.contrib.odmantic import IsActive
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "

--- a/tests/odmantic/test_is_active_integration.py
+++ b/tests/odmantic/test_is_active_integration.py
@@ -1,0 +1,45 @@
+"""Integration tests for ODMantic IsActive mixin."""
+
+import pytest
+from odmantic import Field, Model
+
+from opinionated_mixins.contrib.odmantic import IsActive
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyModel(IsActive, Model):
+    """Test model composing IsActive with Model."""
+
+    model_config = {"collection": "test_is_active"}
+    name: str = Field(...)
+
+
+class TestIsActiveIntegration:
+    """Test IsActive mixin composition, instantiation, and roundtrip."""
+
+    async def test_defaults_true(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        assert loaded is not None
+        assert loaded.is_active is True
+
+    async def test_set_to_false(self, mock_engine) -> None:
+        obj = MyModel(name="test", is_active=False)
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        assert loaded.is_active is False
+
+    async def test_update_persists(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        obj.is_active = False
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        assert loaded.is_active is False

--- a/tests/odmantic/test_is_active_integration.py
+++ b/tests/odmantic/test_is_active_integration.py
@@ -3,8 +3,10 @@
 import pytest
 from odmantic import Field, Model
 from opinionated_mixins.contrib.odmantic import IsActive
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/tests/odmantic/test_is_active_integration.py
+++ b/tests/odmantic/test_is_active_integration.py
@@ -8,7 +8,7 @@ from opinionated_mixins.contrib.odmantic import IsActive
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_lead_integration.py
+++ b/tests/odmantic/test_lead_integration.py
@@ -1,0 +1,86 @@
+"""Integration tests for ODMantic Lead mixin."""
+
+import datetime
+from decimal import Decimal
+
+import pytest
+from odmantic import Model
+
+from opinionated_mixins.contrib.odmantic import Lead
+from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyLead(Lead, Model):
+    """Test model composing Lead with Model."""
+
+    model_config = {"collection": "test_leads"}
+
+
+class TestLeadIntegration:
+    """Test Lead mixin composition, instantiation, and roundtrip."""
+
+    async def test_create_with_defaults(self, mock_engine) -> None:
+        obj = MyLead()
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyLead)
+        assert loaded is not None
+        assert loaded.probability == 0
+        assert loaded.is_active is True
+        assert loaded.title is None
+        assert loaded.status is None
+        assert loaded.source is None
+        assert loaded.rating is None
+
+    async def test_create_with_all_fields(self, mock_engine) -> None:
+        today = datetime.date.today()
+        obj = MyLead(
+            title="Big Deal",
+            salutation="Mr",
+            job_title="CTO",
+            company_name="Acme Corp",
+            website="https://acme.example.com",
+            linkedin_url="https://linkedin.com/in/johndoe",
+            status=LeadStatus.IN_PROCESS,
+            source=LeadSource.EMAIL,
+            industry="Technology",
+            rating=LeadRating.HOT,
+            opportunity_amount=Decimal("50000.00"),
+            currency="USD",
+            probability=75,
+            close_date=today,
+            last_contacted=today,
+            next_follow_up=today,
+            description="A big opportunity",
+            is_active=True,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyLead)
+        assert loaded.title == "Big Deal"
+        assert loaded.salutation == "Mr"
+        assert loaded.job_title == "CTO"
+        assert loaded.company_name == "Acme Corp"
+        assert loaded.status == LeadStatus.IN_PROCESS
+        assert loaded.source == LeadSource.EMAIL
+        assert loaded.rating == LeadRating.HOT
+        assert loaded.probability == 75
+        assert loaded.currency == "USD"
+        assert loaded.description == "A big opportunity"
+
+    async def test_enum_fields_roundtrip(self, mock_engine) -> None:
+        obj = MyLead(
+            status=LeadStatus.CONVERTED,
+            source=LeadSource.PARTNER,
+            rating=LeadRating.COLD,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyLead)
+        assert loaded.status == LeadStatus.CONVERTED
+        assert loaded.source == LeadSource.PARTNER
+        assert loaded.rating == LeadRating.COLD

--- a/tests/odmantic/test_lead_integration.py
+++ b/tests/odmantic/test_lead_integration.py
@@ -12,7 +12,7 @@ from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_lead_integration.py
+++ b/tests/odmantic/test_lead_integration.py
@@ -5,10 +5,8 @@ from decimal import Decimal
 
 import pytest
 from odmantic import Model
-
 from opinionated_mixins.contrib.odmantic import Lead
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "

--- a/tests/odmantic/test_lead_integration.py
+++ b/tests/odmantic/test_lead_integration.py
@@ -7,8 +7,10 @@ import pytest
 from odmantic import Model
 from opinionated_mixins.contrib.odmantic import Lead
 from opinionated_mixins.enums import LeadRating, LeadSource, LeadStatus
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/tests/odmantic/test_person_integration.py
+++ b/tests/odmantic/test_person_integration.py
@@ -5,8 +5,10 @@ import datetime
 import pytest
 from odmantic import Model
 from opinionated_mixins.contrib.odmantic import Person
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/tests/odmantic/test_person_integration.py
+++ b/tests/odmantic/test_person_integration.py
@@ -10,7 +10,7 @@ from opinionated_mixins.contrib.odmantic import Person
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_person_integration.py
+++ b/tests/odmantic/test_person_integration.py
@@ -1,0 +1,75 @@
+"""Integration tests for ODMantic Person mixin."""
+
+import datetime
+
+import pytest
+from odmantic import Model
+
+from opinionated_mixins.contrib.odmantic import Person
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyPerson(Person, Model):
+    """Test model composing Person with Model."""
+
+    model_config = {"collection": "test_persons"}
+
+
+class TestPersonIntegration:
+    """Test Person mixin composition, instantiation, and roundtrip."""
+
+    async def test_create_with_required_fields(self, mock_engine) -> None:
+        obj = MyPerson(first_name="Alice", last_name="Smith")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyPerson)
+        assert loaded is not None
+        assert loaded.first_name == "Alice"
+        assert loaded.last_name == "Smith"
+        assert loaded.middle_name is None
+        assert loaded.phone_number is None
+        assert loaded.email is None
+
+    async def test_create_with_all_fields(self, mock_engine) -> None:
+        dob = datetime.date(1990, 1, 15)
+        obj = MyPerson(
+            first_name="Bob",
+            last_name="Jones",
+            middle_name="M",
+            phone_number="+1234567890",
+            email="bob@example.com",
+            street_address="123 Main St",
+            postal_code="12345",
+            city="Springfield",
+            country="US",
+            date_of_birth=dob,
+            bio="A test person",
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyPerson)
+        assert loaded.first_name == "Bob"
+        assert loaded.middle_name == "M"
+        assert loaded.phone_number == "+1234567890"
+        assert loaded.email == "bob@example.com"
+        assert loaded.street_address == "123 Main St"
+        assert loaded.postal_code == "12345"
+        assert loaded.city == "Springfield"
+        assert loaded.country == "US"
+        assert loaded.date_of_birth == dob
+        assert loaded.bio == "A test person"
+
+    async def test_optional_fields_default_none(self, mock_engine) -> None:
+        obj = MyPerson(first_name="C", last_name="D")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyPerson)
+        assert loaded.street_address is None
+        assert loaded.postal_code is None
+        assert loaded.city is None
+        assert loaded.country is None
+        assert loaded.date_of_birth is None
+        assert loaded.bio is None

--- a/tests/odmantic/test_person_integration.py
+++ b/tests/odmantic/test_person_integration.py
@@ -4,9 +4,7 @@ import datetime
 
 import pytest
 from odmantic import Model
-
 from opinionated_mixins.contrib.odmantic import Person
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "

--- a/tests/odmantic/test_template_integration.py
+++ b/tests/odmantic/test_template_integration.py
@@ -9,7 +9,7 @@ from opinionated_mixins.enums import TemplateFormat, TemplateType
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_template_integration.py
+++ b/tests/odmantic/test_template_integration.py
@@ -2,10 +2,8 @@
 
 import pytest
 from odmantic import Model
-
 from opinionated_mixins.contrib.odmantic import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "

--- a/tests/odmantic/test_template_integration.py
+++ b/tests/odmantic/test_template_integration.py
@@ -1,0 +1,60 @@
+"""Integration tests for ODMantic Template mixin."""
+
+import pytest
+from odmantic import Model
+
+from opinionated_mixins.contrib.odmantic import Template
+from opinionated_mixins.enums import TemplateFormat, TemplateType
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyTemplate(Template, Model):
+    """Test model composing Template with Model."""
+
+    model_config = {"collection": "test_templates"}
+
+
+class TestTemplateIntegration:
+    """Test Template mixin composition, instantiation, and roundtrip."""
+
+    async def test_create_with_defaults(self, mock_engine) -> None:
+        obj = MyTemplate(name="Welcome", content="Hello {{name}}")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyTemplate)
+        assert loaded is not None
+        assert loaded.name == "Welcome"
+        assert loaded.content == "Hello {{name}}"
+        assert loaded.format == TemplateFormat.PLAIN
+        assert loaded.type == TemplateType.OTHER
+
+    async def test_create_with_explicit_values(self, mock_engine) -> None:
+        obj = MyTemplate(
+            name="Newsletter",
+            content="<h1>News</h1>",
+            format=TemplateFormat.HTML,
+            type=TemplateType.EMAIL,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyTemplate)
+        assert loaded.format == TemplateFormat.HTML
+        assert loaded.type == TemplateType.EMAIL
+
+    async def test_roundtrip_preserves_all_fields(self, mock_engine) -> None:
+        obj = MyTemplate(
+            name="Alert",
+            content="# Alert",
+            format=TemplateFormat.MARKDOWN,
+            type=TemplateType.PUSH,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyTemplate)
+        assert loaded.name == "Alert"
+        assert loaded.content == "# Alert"
+        assert loaded.format == TemplateFormat.MARKDOWN
+        assert loaded.type == TemplateType.PUSH

--- a/tests/odmantic/test_template_integration.py
+++ b/tests/odmantic/test_template_integration.py
@@ -4,8 +4,10 @@ import pytest
 from odmantic import Model
 from opinionated_mixins.contrib.odmantic import Template
 from opinionated_mixins.enums import TemplateFormat, TemplateType
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/tests/odmantic/test_updated_at_integration.py
+++ b/tests/odmantic/test_updated_at_integration.py
@@ -4,9 +4,7 @@ import datetime
 
 import pytest
 from odmantic import Field, Model
-
 from opinionated_mixins.contrib.odmantic import UpdatedAt
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
@@ -38,7 +36,8 @@ class TestUpdatedAtIntegration:
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(MyModel)
         now = datetime.datetime.now(datetime.timezone.utc)
-        delta = (now - loaded.updated_at.replace(tzinfo=datetime.timezone.utc)).total_seconds()
+        utc = datetime.timezone.utc
+        delta = (now - loaded.updated_at.replace(tzinfo=utc)).total_seconds()
         assert delta < 5
 
     async def test_updated_at_survives_roundtrip(self, mock_engine) -> None:
@@ -46,4 +45,5 @@ class TestUpdatedAtIntegration:
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(MyModel)
         # mongomock may truncate microseconds; compare up to millisecond precision
-        assert abs((loaded.updated_at - obj.updated_at.replace(tzinfo=None)).total_seconds()) < 0.01
+        diff = loaded.updated_at - obj.updated_at.replace(tzinfo=None)
+        assert abs(diff.total_seconds()) < 0.01

--- a/tests/odmantic/test_updated_at_integration.py
+++ b/tests/odmantic/test_updated_at_integration.py
@@ -5,8 +5,10 @@ import datetime
 import pytest
 from odmantic import Field, Model
 from opinionated_mixins.contrib.odmantic import UpdatedAt
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/tests/odmantic/test_updated_at_integration.py
+++ b/tests/odmantic/test_updated_at_integration.py
@@ -1,0 +1,49 @@
+"""Integration tests for ODMantic UpdatedAt mixin."""
+
+import datetime
+
+import pytest
+from odmantic import Field, Model
+
+from opinionated_mixins.contrib.odmantic import UpdatedAt
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyModel(UpdatedAt, Model):
+    """Test model composing UpdatedAt with Model."""
+
+    model_config = {"collection": "test_updated_at"}
+    name: str = Field(...)
+
+
+class TestUpdatedAtIntegration:
+    """Test UpdatedAt mixin composition, instantiation, and roundtrip."""
+
+    async def test_updated_at_set_on_save(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        assert loaded is not None
+        assert loaded.updated_at is not None
+        assert isinstance(loaded.updated_at, datetime.datetime)
+
+    async def test_updated_at_is_recent(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        delta = (now - loaded.updated_at.replace(tzinfo=datetime.timezone.utc)).total_seconds()
+        assert delta < 5
+
+    async def test_updated_at_survives_roundtrip(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        # mongomock may truncate microseconds; compare up to millisecond precision
+        assert abs((loaded.updated_at - obj.updated_at.replace(tzinfo=None)).total_seconds()) < 0.01

--- a/tests/odmantic/test_updated_at_integration.py
+++ b/tests/odmantic/test_updated_at_integration.py
@@ -10,7 +10,7 @@ from opinionated_mixins.contrib.odmantic import UpdatedAt
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_updated_at_integration.py
+++ b/tests/odmantic/test_updated_at_integration.py
@@ -49,3 +49,15 @@ class TestUpdatedAtIntegration:
         # mongomock may truncate microseconds; compare up to millisecond precision
         diff = loaded.updated_at - obj.updated_at.replace(tzinfo=None)
         assert abs(diff.total_seconds()) < 0.01
+
+    async def test_updated_at_can_be_manually_refreshed(self, mock_engine) -> None:
+        obj = MyModel(name="test")
+        await mock_engine.save(obj)
+        first_updated = obj.updated_at
+        # Mixin provides the field; consumer is responsible for updating it
+        obj.updated_at = datetime.datetime.now(datetime.timezone.utc)
+        obj.name = "changed"
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyModel)
+        assert loaded.name == "changed"
+        assert loaded.updated_at >= first_updated

--- a/tests/odmantic/test_user_integration.py
+++ b/tests/odmantic/test_user_integration.py
@@ -10,7 +10,7 @@ from opinionated_mixins.contrib.odmantic import User
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "
-    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 

--- a/tests/odmantic/test_user_integration.py
+++ b/tests/odmantic/test_user_integration.py
@@ -1,0 +1,60 @@
+"""Integration tests for ODMantic User mixin."""
+
+import datetime
+
+import pytest
+from odmantic import Model
+
+from opinionated_mixins.contrib.odmantic import User
+
+
+pytestmark = pytest.mark.xfail(
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/TODO",
+    strict=True,
+)
+
+
+class MyUser(User, Model):
+    """Test model composing User with Model."""
+
+    model_config = {"collection": "test_users"}
+
+
+class TestUserIntegration:
+    """Test User mixin composition, instantiation, and roundtrip."""
+
+    async def test_create_with_required_fields(self, mock_engine) -> None:
+        obj = MyUser(username="alice", hashed_password="hashed123")
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyUser)
+        assert loaded is not None
+        assert loaded.username == "alice"
+        assert loaded.hashed_password == "hashed123"
+        assert loaded.email is None
+        assert loaded.date_email_verified is None
+
+    async def test_create_with_all_fields(self, mock_engine) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        obj = MyUser(
+            username="bob",
+            hashed_password="hashed456",
+            email="bob@example.com",
+            date_email_verified=now,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyUser)
+        assert loaded.email == "bob@example.com"
+        assert loaded.date_email_verified is not None
+
+    async def test_roundtrip_preserves_all_fields(self, mock_engine) -> None:
+        obj = MyUser(
+            username="charlie",
+            hashed_password="hashed789",
+            email="charlie@example.com",
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyUser)
+        assert loaded.username == "charlie"
+        assert loaded.hashed_password == "hashed789"
+        assert loaded.email == "charlie@example.com"

--- a/tests/odmantic/test_user_integration.py
+++ b/tests/odmantic/test_user_integration.py
@@ -4,9 +4,7 @@ import datetime
 
 import pytest
 from odmantic import Model
-
 from opinionated_mixins.contrib.odmantic import User
-
 
 pytestmark = pytest.mark.xfail(
     reason="ODMantic metaclass does not process annotations from mixin parents. "

--- a/tests/odmantic/test_user_integration.py
+++ b/tests/odmantic/test_user_integration.py
@@ -5,8 +5,10 @@ import datetime
 import pytest
 from odmantic import Model
 from opinionated_mixins.contrib.odmantic import User
+from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,129 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -148,6 +271,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -211,6 +348,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -320,6 +466,33 @@ wheels = [
 ]
 
 [[package]]
+name = "mongomock"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytz" },
+    { name = "sentinels" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/a4/4a560a9f2a0bec43d5f63104f55bc48666d619ca74825c8ae156b08547cf/mongomock-4.3.0.tar.gz", hash = "sha256:32667b79066fabc12d4f17f16a8fd7361b5f4435208b3ba32c226e52212a8c30", size = 135862, upload-time = "2024-11-16T11:23:25.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/4d/8bea712978e3aff017a2ab50f262c620e9239cc36f348aae45e48d6a4786/mongomock-4.3.0-py2.py3-none-any.whl", hash = "sha256:5ef86bd12fc8806c6e7af32f21266c61b6c4ba96096f85129852d1c4fec1327e", size = 64891, upload-time = "2024-11-16T11:23:24.748Z" },
+]
+
+[[package]]
+name = "mongomock-motor"
+version = "0.0.36"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mongomock" },
+    { name = "motor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/9f/38e42a34ebad323addaf6296d6b5d83eaf2c423adf206b757c68315e196a/mongomock_motor-0.0.36.tar.gz", hash = "sha256:3cf62352ece5af2f02e04d2f252393f88b5fe0487997da00584020cee4b8efba", size = 5754, upload-time = "2025-05-16T22:52:27.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/99/f5fdbbdc96bfd03e5f9c36339547a9076f5dbb5882900b7621526d41a38d/mongomock_motor-0.0.36-py3-none-any.whl", hash = "sha256:3ecb7949662b8986ff9c267fa0b1402b5b75a6afd57f03850cd6e13a067e3691", size = 7334, upload-time = "2025-05-16T22:52:25.417Z" },
+]
+
+[[package]]
 name = "motor"
 version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -421,9 +594,13 @@ source = { editable = "." }
 dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "mongoengine" },
+    { name = "mongomock" },
+    { name = "mongomock-motor" },
     { name = "odmantic" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "sqlalchemy" },
+    { name = "testcontainers", extra = ["mongodb"] },
 ]
 types = [
     { name = "mypy" },
@@ -436,9 +613,13 @@ types = [
 dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.13.5" },
     { name = "mongoengine", specifier = "==0.29.3" },
+    { name = "mongomock", specifier = ">=4.3.0" },
+    { name = "mongomock-motor", specifier = ">=0.0.32" },
     { name = "odmantic", specifier = "==1.1.0" },
     { name = "pytest", specifier = "==9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
+    { name = "testcontainers", extras = ["mongodb"], specifier = ">=4.10.0" },
 ]
 types = [
     { name = "mypy", specifier = ">=1.20.1" },
@@ -702,6 +883,75 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.11"
 source = { registry = "https://pypi.org/simple" }
@@ -724,6 +974,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
+name = "sentinels"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/9b/07195878aa25fe6ed209ec74bc55ae3e3d263b60a489c6e73fdca3c8fe05/sentinels-1.1.1.tar.gz", hash = "sha256:3c2f64f754187c19e0a1a029b148b74cf58dd12ec27b4e19c0e5d6e22b5a9a86", size = 4393, upload-time = "2025-08-12T07:57:50.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/65/dea992c6a97074f6d8ff9eab34741298cac2ce23e2b6c74fb7d08afdf85c/sentinels-1.1.1-py3-none-any.whl", hash = "sha256:835d3b28f3b47f5284afa4bf2db6e00f2dc5f80f9923d4b7e7aeeeccf6146a11", size = 3744, upload-time = "2025-08-12T07:57:48.858Z" },
 ]
 
 [[package]]
@@ -784,6 +1043,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
     { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
     { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[package.optional-dependencies]
+mongodb = [
+    { name = "pymongo" },
 ]
 
 [[package]]
@@ -859,4 +1139,99 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/d2/387594fb592d027366645f3d7cc9b4d7ca7be93845fbaba6d835a912ef3c/wrapt-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a86d99a14f76facb269dc148590c01aaf47584071809a70da30555228158c", size = 60669, upload-time = "2026-03-06T02:52:40.671Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/18/3f373935bc5509e7ac444c8026a56762e50c1183e7061797437ca96c12ce/wrapt-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a819e39017f95bf7aede768f75915635aa8f671f2993c036991b8d3bfe8dbb6f", size = 61603, upload-time = "2026-03-06T02:54:21.032Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/7a/32758ca2853b07a887a4574b74e28843919103194bb47001a304e24af62f/wrapt-2.1.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5681123e60aed0e64c7d44f72bbf8b4ce45f79d81467e2c4c728629f5baf06eb", size = 113632, upload-time = "2026-03-06T02:53:54.121Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d5/eeaa38f670d462e97d978b3b0d9ce06d5b91e54bebac6fbed867809216e7/wrapt-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8b28e97a44d21836259739ae76284e180b18abbb4dcfdff07a415cf1016c3e", size = 115644, upload-time = "2026-03-06T02:54:53.33Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/09/2a41506cb17affb0bdf9d5e2129c8c19e192b388c4c01d05e1b14db23c00/wrapt-2.1.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cef91c95a50596fcdc31397eb6955476f82ae8a3f5a8eabdc13611b60ee380ba", size = 112016, upload-time = "2026-03-06T02:54:43.274Z" },
+    { url = "https://files.pythonhosted.org/packages/64/15/0e6c3f5e87caadc43db279724ee36979246d5194fa32fed489c73643ba59/wrapt-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dad63212b168de8569b1c512f4eac4b57f2c6934b30df32d6ee9534a79f1493f", size = 114823, upload-time = "2026-03-06T02:54:29.392Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b2/0ad17c8248f4e57bedf44938c26ec3ee194715f812d2dbbd9d7ff4be6c06/wrapt-2.1.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d307aa6888d5efab2c1cde09843d48c843990be13069003184b67d426d145394", size = 111244, upload-time = "2026-03-06T02:54:02.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/04/bcdba98c26f2c6522c7c09a726d5d9229120163493620205b2f76bd13c01/wrapt-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c87cf3f0c85e27b3ac7d9ad95da166bf8739ca215a8b171e8404a2d739897a45", size = 113307, upload-time = "2026-03-06T02:54:12.428Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1b/5e2883c6bc14143924e465a6fc5a92d09eeabe35310842a481fb0581f832/wrapt-2.1.2-cp310-cp310-win32.whl", hash = "sha256:d1c5fea4f9fe3762e2b905fdd67df51e4be7a73b7674957af2d2ade71a5c075d", size = 57986, upload-time = "2026-03-06T02:54:26.823Z" },
+    { url = "https://files.pythonhosted.org/packages/42/5a/4efc997bccadd3af5749c250b49412793bc41e13a83a486b2b54a33e240c/wrapt-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:d8f7740e1af13dff2684e4d56fe604a7e04d6c94e737a60568d8d4238b9a0c71", size = 60336, upload-time = "2026-03-06T02:54:18Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f5/a2bb833e20181b937e87c242645ed5d5aa9c373006b0467bfe1a35c727d0/wrapt-2.1.2-cp310-cp310-win_arm64.whl", hash = "sha256:1c6cc827c00dc839350155f316f1f8b4b0c370f52b6a19e782e2bda89600c7dc", size = 58757, upload-time = "2026-03-06T02:53:51.545Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]


### PR DESCRIPTION
## Summary

- Add mongomock, mongomock-motor, testcontainers, pytest-asyncio to dev deps
- Add MongoEngine integration tests for all 9 mixins (composition + instantiation + roundtrip via mongomock)
- Add ODMantic integration tests for all 9 mixins (marked `xfail` — mixin composition broken, see #39)
- Add pytest markers for real MongoDB tests via testcontainers (`pytest -m mongo`)
- Add per-file ruff ignores for test-specific patterns (RUF012, ANN001, DTZ011)

## Bug discovered

ODMantic's metaclass does not process `__annotations__` from mixin parent classes. `Field()` defaults stay as raw `ODMFieldInfo` objects, causing `ValidationError` on instantiation. Filed as #39. All ODMantic integration tests use `strict=True` xfail — they'll auto-fail when the bug is fixed.

## Test results

```
190 passed, 27 xfailed, 0 failed
```

## Test plan

- [x] All existing tests pass (no regressions)
- [x] MongoEngine integration tests pass (27 new tests)
- [x] ODMantic integration tests xfail as expected (27 new tests)
- [x] `ruff check` passes
- [x] `ruff format --check` passes

Closes #36 (integration tests portion; examples deferred to follow-up)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive integration tests for MongoEngine and ODMantic mixins, covering all 9 mixin types (CreatedAt, UpdatedAt, IsActive, User, Person, Announcement, Feedback, Template, Lead). The tests verify mixin composition, instantiation, and database roundtrip behavior using `mongomock` for MongoEngine and `mongomock-motor` for ODMantic. A bug was discovered in ODMantic where the metaclass fails to process annotations from mixin parent classes, causing validation errors. All 27 ODMantic tests are marked `xfail` with `strict=True` and reference issue #39. The PR also adds development dependencies (`mongomock`, `mongomock-motor`, `testcontainers`, `pytest-asyncio`), configures pytest markers for real MongoDB tests, and updates ruff configuration to ignore test-specific patterns like `RUF012`, `ANN001`, and `DTZ011`.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `pyproject.toml` |
| 2 | `tests/mongoengine/conftest.py` |
| 3 | `tests/odmantic/conftest.py` |
| 4 | `tests/mongoengine/test_created_at_integration.py` |
| 5 | `tests/mongoengine/test_updated_at_integration.py` |
| 6 | `tests/mongoengine/test_is_active_integration.py` |
| 7 | `tests/mongoengine/test_user_integration.py` |
| 8 | `tests/mongoengine/test_person_integration.py` |
| 9 | `tests/mongoengine/test_announcement_integration.py` |
| 10 | `tests/mongoengine/test_feedback_integration.py` |
| 11 | `tests/mongoengine/test_template_integration.py` |
| 12 | `tests/mongoengine/test_lead_integration.py` |
| 13 | `tests/odmantic/test_created_at_integration.py` |
| 14 | `tests/odmantic/test_updated_at_integration.py` |
| 15 | `tests/odmantic/test_is_active_integration.py` |
| 16 | `tests/odmantic/test_user_integration.py` |
| 17 | `tests/odmantic/test_person_integration.py` |
| 18 | `tests/odmantic/test_announcement_integration.py` |
| 19 | `tests/odmantic/test_feedback_integration.py` |
| 20 | `tests/odmantic/test_template_integration.py` |
| 21 | `tests/odmantic/test_lead_integration.py` |
| 22 | `uv.lock` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->