### PR TITLE
feat: add ActivityMixin for event-level activity records (#42)

### DIFF
--- a/src/opinionated_mixins/contrib/mongoengine/__init__.py
+++ b/src/opinionated_mixins/contrib/mongoengine/__init__.py
@@ -1,3 +1,4 @@
+from .activity import Activity as Activity
 from .announcement import Announcement as Announcement
 from .created_at import CreatedAt as CreatedAt
 from .feedback import Feedback as Feedback

--- a/src/opinionated_mixins/contrib/mongoengine/activity.py
+++ b/src/opinionated_mixins/contrib/mongoengine/activity.py
@@ -1,0 +1,76 @@
+import datetime
+from typing import Any, ClassVar
+
+from mongoengine import BooleanField, DateTimeField, DictField, StringField
+
+
+class Activity:
+    """Activity mixin for MongoEngine documents.
+
+    Event-level activity record following the W3C Activity Streams 2.0
+    sentence pattern: {actor} {verb} {action_object} on {target}.
+
+    Three polymorphic pairs track the entities involved:
+    - actor (required): who performed the action
+    - target (optional): what the action was performed on
+    - action_object (optional): what was created or used by the action
+    """
+
+    meta: ClassVar[dict[str, Any]] = {"allow_inheritance": True}
+
+    verb = StringField(
+        required=True,
+        max_length=255,
+        index=True,
+        help_text="Action performed (e.g. 'created', 'commented', 'merged')",
+    )
+    description = StringField(
+        help_text="Human-readable summary of the activity",
+    )
+    data = DictField(
+        help_text="Arbitrary JSON payload for extra context",
+    )
+    actor_type = StringField(
+        required=True,
+        max_length=255,
+        index=True,
+        help_text="Polymorphic type of entity that performed the action",
+    )
+    actor_id = StringField(
+        required=True,
+        max_length=255,
+        index=True,
+        help_text="Polymorphic ID of entity that performed the action",
+    )
+    target_type = StringField(
+        max_length=255,
+        index=True,
+        help_text="Polymorphic type of entity the action was performed on",
+    )
+    target_id = StringField(
+        max_length=255,
+        index=True,
+        help_text="Polymorphic ID of entity the action was performed on",
+    )
+    action_object_type = StringField(
+        max_length=255,
+        index=True,
+        help_text="Polymorphic type of entity created/used by the action",
+    )
+    action_object_id = StringField(
+        max_length=255,
+        index=True,
+        help_text="Polymorphic ID of entity created/used by the action",
+    )
+    public = BooleanField(
+        required=True,
+        default=True,
+        index=True,
+        help_text="Whether activity is visible to non-participants",
+    )
+    created_at = DateTimeField(
+        required=True,
+        index=True,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        help_text="When activity occurred",
+    )

--- a/src/opinionated_mixins/contrib/mongoengine/activity.py
+++ b/src/opinionated_mixins/contrib/mongoengine/activity.py
@@ -28,6 +28,7 @@ class Activity:
         help_text="Human-readable summary of the activity",
     )
     data = DictField(
+        default=None,
         help_text="Arbitrary JSON payload for extra context",
     )
     actor_type = StringField(

--- a/src/opinionated_mixins/contrib/odmantic/__init__.py
+++ b/src/opinionated_mixins/contrib/odmantic/__init__.py
@@ -1,3 +1,4 @@
+from .activity import Activity as Activity
 from .announcement import Announcement as Announcement
 from .created_at import CreatedAt as CreatedAt
 from .feedback import Feedback as Feedback

--- a/src/opinionated_mixins/contrib/odmantic/activity.py
+++ b/src/opinionated_mixins/contrib/odmantic/activity.py
@@ -1,0 +1,69 @@
+import datetime
+from typing import Any
+
+from odmantic import Field
+
+
+class Activity:
+    """Activity mixin for ODMantic models.
+
+    Event-level activity record following the W3C Activity Streams 2.0
+    sentence pattern: {actor} {verb} {action_object} on {target}.
+
+    Three polymorphic pairs track the entities involved:
+    - actor (required): who performed the action
+    - target (optional): what the action was performed on
+    - action_object (optional): what was created or used by the action
+    """
+
+    verb: str = Field(
+        ...,
+        max_length=255,
+        description="Action performed (e.g. 'created', 'commented', 'merged')",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Human-readable summary of the activity",
+    )
+    data: dict[str, Any] | None = Field(
+        default=None,
+        description="Arbitrary JSON payload for extra context",
+    )
+    actor_type: str = Field(
+        ...,
+        max_length=255,
+        description="Polymorphic type of entity that performed the action",
+    )
+    actor_id: str = Field(
+        ...,
+        max_length=255,
+        description="Polymorphic ID of entity that performed the action",
+    )
+    target_type: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Polymorphic type of entity the action was performed on",
+    )
+    target_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Polymorphic ID of entity the action was performed on",
+    )
+    action_object_type: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Polymorphic type of entity created/used by the action",
+    )
+    action_object_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Polymorphic ID of entity created/used by the action",
+    )
+    public: bool = Field(
+        default=True,
+        description="Whether activity is visible to non-participants",
+    )
+    created_at: datetime.datetime = Field(
+        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc),
+        description="When activity occurred",
+    )

--- a/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/__init__.py
@@ -1,3 +1,4 @@
+from .activity import Activity as Activity
 from .announcement import Announcement as Announcement
 from .created_at import CreatedAt as CreatedAt
 from .feedback import Feedback as Feedback

--- a/src/opinionated_mixins/contrib/sqlalchemy/activity.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/activity.py
@@ -35,8 +35,8 @@ class Activity:
         nullable=True,
         doc=(
             "Arbitrary JSON payload for extra context. "
-            "Write-once: set at creation. To update, reassign the entire object "
-            "(in-place dict mutations are not tracked by SQLAlchemy)."
+            "In-place dict mutations are not tracked by SQLAlchemy; "
+            "reassign the entire object to trigger change detection."
         ),
     )
     actor_type = Column(

--- a/src/opinionated_mixins/contrib/sqlalchemy/activity.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/activity.py
@@ -1,0 +1,91 @@
+import datetime
+
+from sqlalchemy import JSON, Boolean, Column, DateTime, String, Text
+from sqlalchemy.orm import declarative_mixin
+
+
+@declarative_mixin
+class Activity:
+    """Activity mixin for SQLAlchemy models.
+
+    Event-level activity record following the W3C Activity Streams 2.0
+    sentence pattern: {actor} {verb} {action_object} on {target}.
+
+    Three polymorphic pairs track the entities involved:
+    - actor (required): who performed the action
+    - target (optional): what the action was performed on
+    - action_object (optional): what was created or used by the action
+    """
+
+    __abstract__ = True
+
+    verb = Column(
+        String(255),
+        nullable=False,
+        index=True,
+        doc="Action performed (e.g. 'created', 'commented', 'merged')",
+    )
+    description = Column(
+        Text,
+        nullable=True,
+        doc="Human-readable summary of the activity",
+    )
+    data = Column(
+        JSON,
+        nullable=True,
+        doc=(
+            "Arbitrary JSON payload for extra context. "
+            "Write-once: set at creation. To update, reassign the entire object "
+            "(in-place dict mutations are not tracked by SQLAlchemy)."
+        ),
+    )
+    actor_type = Column(
+        String(255),
+        nullable=False,
+        index=True,
+        doc="Polymorphic type of entity that performed the action",
+    )
+    actor_id = Column(
+        String(255),
+        nullable=False,
+        index=True,
+        doc="Polymorphic ID of entity that performed the action",
+    )
+    target_type = Column(
+        String(255),
+        nullable=True,
+        index=True,
+        doc="Polymorphic type of entity the action was performed on",
+    )
+    target_id = Column(
+        String(255),
+        nullable=True,
+        index=True,
+        doc="Polymorphic ID of entity the action was performed on",
+    )
+    action_object_type = Column(
+        String(255),
+        nullable=True,
+        index=True,
+        doc="Polymorphic type of entity created/used by the action",
+    )
+    action_object_id = Column(
+        String(255),
+        nullable=True,
+        index=True,
+        doc="Polymorphic ID of entity created/used by the action",
+    )
+    public = Column(
+        Boolean,
+        nullable=False,
+        index=True,
+        default=True,
+        doc="Whether activity is visible to non-participants",
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+        default=lambda: datetime.datetime.now(datetime.timezone.utc),
+        doc="When activity occurred",
+    )

--- a/src/opinionated_mixins/contrib/sqlalchemy/notification.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/notification.py
@@ -47,8 +47,8 @@ class Notification:
         nullable=True,
         doc=(
             "Arbitrary JSON payload for extra context. "
-            "Write-once: set at creation. To update, reassign the entire object "
-            "(in-place dict mutations are not tracked by SQLAlchemy)."
+            "In-place dict mutations are not tracked by SQLAlchemy; "
+            "reassign the entire object to trigger change detection."
         ),
     )
     actor_type = Column(

--- a/src/opinionated_mixins/contrib/sqlmodel/__init__.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/__init__.py
@@ -1,3 +1,4 @@
+from .activity import Activity as Activity
 from .announcement import Announcement as Announcement
 from .created_at import CreatedAt as CreatedAt
 from .feedback import Feedback as Feedback

--- a/src/opinionated_mixins/contrib/sqlmodel/activity.py
+++ b/src/opinionated_mixins/contrib/sqlmodel/activity.py
@@ -1,0 +1,3 @@
+from opinionated_mixins.contrib.sqlalchemy.activity import (
+    Activity as Activity,
+)

--- a/tests/mongoengine/test_activity.py
+++ b/tests/mongoengine/test_activity.py
@@ -1,0 +1,48 @@
+from opinionated_mixins.contrib.mongoengine import Activity
+
+
+class TestMongoEngineActivity:
+    def test_has_verb_field(self) -> None:
+        assert hasattr(Activity, "verb")
+        assert Activity.verb.required is True
+        assert Activity.verb.max_length == 255
+
+    def test_has_description_field(self) -> None:
+        assert hasattr(Activity, "description")
+        assert Activity.description.required is False
+
+    def test_has_data_field(self) -> None:
+        assert hasattr(Activity, "data")
+
+    def test_has_actor_fields(self) -> None:
+        assert hasattr(Activity, "actor_type")
+        assert Activity.actor_type.required is True
+        assert Activity.actor_type.max_length == 255
+        assert hasattr(Activity, "actor_id")
+        assert Activity.actor_id.required is True
+        assert Activity.actor_id.max_length == 255
+
+    def test_has_target_fields(self) -> None:
+        assert hasattr(Activity, "target_type")
+        assert Activity.target_type.required is False
+        assert Activity.target_type.max_length == 255
+        assert hasattr(Activity, "target_id")
+        assert Activity.target_id.required is False
+        assert Activity.target_id.max_length == 255
+
+    def test_has_action_object_fields(self) -> None:
+        assert hasattr(Activity, "action_object_type")
+        assert Activity.action_object_type.required is False
+        assert Activity.action_object_type.max_length == 255
+        assert hasattr(Activity, "action_object_id")
+        assert Activity.action_object_id.required is False
+        assert Activity.action_object_id.max_length == 255
+
+    def test_has_public_field(self) -> None:
+        assert hasattr(Activity, "public")
+        assert Activity.public.required is True
+        assert Activity.public.default is True
+
+    def test_has_created_at_field(self) -> None:
+        assert hasattr(Activity, "created_at")
+        assert Activity.created_at.required is True

--- a/tests/mongoengine/test_activity_integration.py
+++ b/tests/mongoengine/test_activity_integration.py
@@ -1,0 +1,93 @@
+"""Integration tests for MongoEngine Activity mixin."""
+
+import datetime
+
+from mongoengine import Document
+from opinionated_mixins.contrib.mongoengine import Activity
+
+
+class MyActivity(Activity, Document):
+    """Test model composing Activity with Document."""
+
+    meta = {"collection": "test_activities"}
+
+
+class TestActivityIntegration:
+    """Test Activity mixin composition, instantiation, and roundtrip."""
+
+    def test_create_with_required_fields(self) -> None:
+        obj = MyActivity(
+            verb="commented",
+            actor_type="User",
+            actor_id="42",
+        )
+        obj.save()
+        loaded = MyActivity.objects.first()
+        assert loaded is not None
+        assert loaded.verb == "commented"
+        assert loaded.actor_type == "User"
+        assert loaded.actor_id == "42"
+        assert loaded.public is True
+
+    def test_optional_fields_null_by_default(self) -> None:
+        obj = MyActivity(
+            verb="deployed",
+            actor_type="System",
+            actor_id="system",
+        )
+        obj.save()
+        loaded = MyActivity.objects.first()
+        assert loaded is not None
+        assert loaded.description is None
+        assert loaded.target_type is None
+        assert loaded.target_id is None
+        assert loaded.action_object_type is None
+        assert loaded.action_object_id is None
+
+    def test_public_defaults_true(self) -> None:
+        obj = MyActivity(
+            verb="created",
+            actor_type="User",
+            actor_id="1",
+        )
+        obj.save()
+        loaded = MyActivity.objects.first()
+        assert loaded is not None
+        assert loaded.public is True
+
+    def test_roundtrip_preserves_all_fields(self) -> None:
+        obj = MyActivity(
+            verb="commented",
+            description="Alice commented on a pull request",
+            data={"comment_id": "5"},
+            actor_type="User",
+            actor_id="42",
+            target_type="PullRequest",
+            target_id="99",
+            action_object_type="Comment",
+            action_object_id="5",
+            public=False,
+        )
+        obj.save()
+        loaded = MyActivity.objects.first()
+        assert loaded.verb == "commented"
+        assert loaded.description == "Alice commented on a pull request"
+        assert loaded.data == {"comment_id": "5"}
+        assert loaded.actor_type == "User"
+        assert loaded.actor_id == "42"
+        assert loaded.target_type == "PullRequest"
+        assert loaded.target_id == "99"
+        assert loaded.action_object_type == "Comment"
+        assert loaded.action_object_id == "5"
+        assert loaded.public is False
+
+    def test_created_at_set_on_insert(self) -> None:
+        obj = MyActivity(
+            verb="merged",
+            actor_type="User",
+            actor_id="1",
+        )
+        obj.save()
+        loaded = MyActivity.objects.first()
+        assert loaded.created_at is not None
+        assert isinstance(loaded.created_at, datetime.datetime)

--- a/tests/mongoengine/test_activity_integration.py
+++ b/tests/mongoengine/test_activity_integration.py
@@ -43,6 +43,7 @@ class TestActivityIntegration:
         assert loaded.target_id is None
         assert loaded.action_object_type is None
         assert loaded.action_object_id is None
+        assert loaded.data is None
 
     def test_public_defaults_true(self) -> None:
         obj = MyActivity(

--- a/tests/odmantic/test_activity.py
+++ b/tests/odmantic/test_activity.py
@@ -1,0 +1,20 @@
+from opinionated_mixins.contrib.odmantic import Activity
+
+
+class TestODManticActivity:
+    def test_has_expected_annotations(self) -> None:
+        annotations = Activity.__annotations__
+        assert "verb" in annotations
+        assert "description" in annotations
+        assert "data" in annotations
+        assert "actor_type" in annotations
+        assert "actor_id" in annotations
+        assert "target_type" in annotations
+        assert "target_id" in annotations
+        assert "action_object_type" in annotations
+        assert "action_object_id" in annotations
+        assert "public" in annotations
+        assert "created_at" in annotations
+
+    def test_public_default(self) -> None:
+        assert Activity.public.pydantic_field_info.default is True

--- a/tests/odmantic/test_activity_integration.py
+++ b/tests/odmantic/test_activity_integration.py
@@ -1,0 +1,88 @@
+"""Integration tests for ODMantic Activity mixin."""
+
+import pytest
+from odmantic import Model
+from opinionated_mixins.contrib.odmantic import Activity
+from pydantic import ValidationError
+
+pytestmark = pytest.mark.xfail(
+    raises=(ValidationError, NotImplementedError),
+    reason="ODMantic metaclass does not process annotations from mixin parents. "
+    "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
+    strict=False,
+)
+
+
+class MyActivity(Activity, Model):
+    """Test model composing Activity with Model."""
+
+    model_config = {"collection": "test_activities"}
+
+
+class TestActivityIntegration:
+    """Test Activity mixin composition, instantiation, and roundtrip."""
+
+    async def test_create_with_required_fields(self, mock_engine) -> None:
+        obj = MyActivity(
+            verb="commented",
+            actor_type="User",
+            actor_id="42",
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyActivity)
+        assert loaded is not None
+        assert loaded.verb == "commented"
+        assert loaded.actor_type == "User"
+        assert loaded.actor_id == "42"
+        assert loaded.public is True
+
+    async def test_optional_fields_null_by_default(self, mock_engine) -> None:
+        obj = MyActivity(
+            verb="deployed",
+            actor_type="System",
+            actor_id="system",
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyActivity)
+        assert loaded is not None
+        assert loaded.description is None
+        assert loaded.target_type is None
+        assert loaded.target_id is None
+        assert loaded.action_object_type is None
+        assert loaded.action_object_id is None
+
+    async def test_roundtrip_preserves_all_fields(self, mock_engine) -> None:
+        obj = MyActivity(
+            verb="commented",
+            description="Alice commented on a pull request",
+            data={"comment_id": "5"},
+            actor_type="User",
+            actor_id="42",
+            target_type="PullRequest",
+            target_id="99",
+            action_object_type="Comment",
+            action_object_id="5",
+            public=False,
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyActivity)
+        assert loaded.verb == "commented"
+        assert loaded.description == "Alice commented on a pull request"
+        assert loaded.data == {"comment_id": "5"}
+        assert loaded.actor_type == "User"
+        assert loaded.actor_id == "42"
+        assert loaded.target_type == "PullRequest"
+        assert loaded.target_id == "99"
+        assert loaded.action_object_type == "Comment"
+        assert loaded.action_object_id == "5"
+        assert loaded.public is False
+
+    async def test_created_at_set_on_insert(self, mock_engine) -> None:
+        obj = MyActivity(
+            verb="merged",
+            actor_type="User",
+            actor_id="1",
+        )
+        await mock_engine.save(obj)
+        loaded = await mock_engine.find_one(MyActivity)
+        assert loaded.created_at is not None

--- a/tests/odmantic/test_activity_integration.py
+++ b/tests/odmantic/test_activity_integration.py
@@ -1,5 +1,7 @@
 """Integration tests for ODMantic Activity mixin."""
 
+import datetime
+
 import pytest
 from odmantic import Model
 from opinionated_mixins.contrib.odmantic import Activity
@@ -86,3 +88,5 @@ class TestActivityIntegration:
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(MyActivity)
         assert loaded.created_at is not None
+        assert isinstance(loaded.created_at, datetime.datetime)
+        assert loaded.created_at.tzinfo is not None

--- a/tests/sqlalchemy/test_activity.py
+++ b/tests/sqlalchemy/test_activity.py
@@ -1,0 +1,133 @@
+import datetime
+
+from opinionated_mixins.contrib.sqlalchemy import Activity
+from sqlalchemy import Column, Integer, create_engine
+from sqlalchemy.orm import Session, declarative_base
+
+Base = declarative_base()
+
+
+class MyActivity(Activity, Base):  # type: ignore[misc]
+    __tablename__ = "activities"
+    id = Column(Integer, primary_key=True)
+
+
+class TestSQLAlchemyActivity:
+    def setup_method(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+
+    def test_create_with_required_fields(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyActivity(
+                verb="commented",
+                actor_type="User",
+                actor_id="42",
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.verb == "commented"
+            assert obj.actor_type == "User"
+            assert obj.actor_id == "42"
+            assert obj.public is True
+
+    def test_create_with_all_fields(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyActivity(
+                verb="commented",
+                description="Alice commented on a pull request",
+                data={"comment_id": "5"},
+                actor_type="User",
+                actor_id="42",
+                target_type="PullRequest",
+                target_id="99",
+                action_object_type="Comment",
+                action_object_id="5",
+                public=False,
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.verb == "commented"
+            assert obj.description == "Alice commented on a pull request"
+            assert obj.data == {"comment_id": "5"}
+            assert obj.actor_type == "User"
+            assert obj.actor_id == "42"
+            assert obj.target_type == "PullRequest"
+            assert obj.target_id == "99"
+            assert obj.action_object_type == "Comment"
+            assert obj.action_object_id == "5"
+            assert obj.public is False
+
+    def test_created_at_set_on_insert(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyActivity(
+                verb="merged",
+                actor_type="User",
+                actor_id="1",
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.created_at is not None
+            assert isinstance(obj.created_at, datetime.datetime)
+
+    def test_optional_fields_default_null(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyActivity(
+                verb="deployed",
+                actor_type="System",
+                actor_id="system",
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.description is None
+            assert obj.data is None
+            assert obj.target_type is None
+            assert obj.target_id is None
+            assert obj.action_object_type is None
+            assert obj.action_object_id is None
+
+    def test_public_defaults_true(self) -> None:
+        with Session(self.engine) as session:
+            obj = MyActivity(
+                verb="created",
+                actor_type="User",
+                actor_id="1",
+            )
+            session.add(obj)
+            session.commit()
+            session.refresh(obj)
+            assert obj.public is True
+
+    def test_indexed_columns(self) -> None:
+        table = MyActivity.__table__
+        indexed_columns = {col.name for idx in table.indexes for col in idx.columns}
+        assert "verb" in indexed_columns
+        assert "actor_type" in indexed_columns
+        assert "actor_id" in indexed_columns
+        assert "target_type" in indexed_columns
+        assert "target_id" in indexed_columns
+        assert "action_object_type" in indexed_columns
+        assert "action_object_id" in indexed_columns
+        assert "public" in indexed_columns
+        assert "created_at" in indexed_columns
+
+    def test_fields_exist(self) -> None:
+        columns = {c.name for c in MyActivity.__table__.columns}
+        expected = {
+            "verb",
+            "description",
+            "data",
+            "actor_type",
+            "actor_id",
+            "target_type",
+            "target_id",
+            "action_object_type",
+            "action_object_id",
+            "public",
+            "created_at",
+        }
+        assert expected.issubset(columns)

--- a/tests/test_cross_framework_consistency.py
+++ b/tests/test_cross_framework_consistency.py
@@ -31,11 +31,13 @@ from opinionated_mixins.contrib import (
 from sqlalchemy import Column
 
 MIXIN_NAMES = [
+    "Activity",
     "Announcement",
     "CreatedAt",
     "Feedback",
     "IsActive",
     "Lead",
+    "Notification",
     "Person",
     "Template",
     "UpdatedAt",


### PR DESCRIPTION
## Summary

- Add `ActivityMixin` across all four contrib frameworks (SQLAlchemy, SQLModel, MongoEngine, ODMantic) implementing the W3C Activity Streams 2.0 sentence pattern: `{actor} {verb} {action_object} on {target}`
- Three polymorphic pairs: actor (required), target (optional), action_object (optional) — all using string type+ID for framework-agnostic polymorphism
- 11 fields total: `verb`, `description`, `data`, `actor_type/id`, `target_type/id`, `action_object_type/id`, `public`, `created_at`
- Add `Activity` and `Notification` to cross-framework consistency checks

Closes #42

## Test plan

- [x] SQLAlchemy: 7 unit tests (required fields, all fields, auto-timestamp, null defaults, public default, indexed columns, field existence)
- [x] MongoEngine: 8 field-level tests + 5 integration tests with mongomock
- [x] ODMantic: 2 annotation tests + 4 integration tests (xfail per #39)
- [x] Cross-framework consistency: Activity + Notification added to MIXIN_NAMES
- [x] Full suite: 242 passed, 36 xfailed
- [x] mypy strict: no issues in 55 source files
- [x] ruff check + format: all clean

## Summary by Sourcery

Introduce a cross-framework Activity mixin for recording event-level activity with polymorphic actor/target/action_object fields and ensure it is covered by consistency checks.

New Features:
- Add Activity mixin for SQLAlchemy models to capture event-level activity metadata with polymorphic actor, target, and action_object fields.
- Add Activity mixin for MongoEngine documents mirroring the shared activity schema and defaults.
- Add Activity mixin for ODMantic models with typed fields for activity attributes and defaults.

Tests:
- Add unit and integration tests for the Activity mixin in SQLAlchemy, MongoEngine, and ODMantic, including field presence, defaults, indexing, and roundtrip persistence.
- Extend cross-framework consistency tests to include Activity and Notification mixins in the shared mixin name list.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a new `ActivityMixin` across all four supported ORM frameworks (SQLAlchemy, SQLModel, MongoEngine, and ODMantic) to track event-level activity records. The mixin follows the W3C Activity Streams 2.0 pattern with the structure *{actor} {verb} {action_object} on {target}*, implementing 11 fields total including three polymorphic entity pairs (actor, target, action_object) that use string-based type and ID fields for framework-agnostic polymorphism. The implementation includes comprehensive test coverage with field validation, integration tests, and cross-framework consistency checks. The `Activity` and `Notification` mixins are also added to the cross-framework consistency test suite.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tests/test_cross_framework_consistency.py` |
| 2 | `src/opinionated_mixins/contrib/sqlalchemy/activity.py` |
| 3 | `src/opinionated_mixins/contrib/sqlalchemy/__init__.py` |
| 4 | `tests/sqlalchemy/test_activity.py` |
| 5 | `src/opinionated_mixins/contrib/sqlmodel/activity.py` |
| 6 | `src/opinionated_mixins/contrib/sqlmodel/__init__.py` |
| 7 | `src/opinionated_mixins/contrib/mongoengine/activity.py` |
| 8 | `src/opinionated_mixins/contrib/mongoengine/__init__.py` |
| 9 | `tests/mongoengine/test_activity.py` |
| 10 | `tests/mongoengine/test_activity_integration.py` |
| 11 | `src/opinionated_mixins/contrib/odmantic/activity.py` |
| 12 | `src/opinionated_mixins/contrib/odmantic/__init__.py` |
| 13 | `tests/odmantic/test_activity.py` |
| 14 | `tests/odmantic/test_activity_integration.py` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `tests/test_cross_framework_consistency.py` | Adds 'Notification' to MIXIN_NAMES but no Notification mixin implementation is included in this PR |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->