### PR TITLE
feat!: make NotificationMixin actor fields required

### DIFF
--- a/src/opinionated_mixins/contrib/mongoengine/notification.py
+++ b/src/opinionated_mixins/contrib/mongoengine/notification.py
@@ -45,11 +45,13 @@ class Notification:
         help_text="Arbitrary JSON payload for extra context",
     )
     actor_type = StringField(
+        required=True,
         max_length=255,
         index=True,
         help_text="Polymorphic type of entity that triggered notification",
     )
     actor_id = StringField(
+        required=True,
         max_length=255,
         index=True,
         help_text="Polymorphic ID of entity that triggered notification",

--- a/src/opinionated_mixins/contrib/odmantic/notification.py
+++ b/src/opinionated_mixins/contrib/odmantic/notification.py
@@ -40,13 +40,13 @@ class Notification:
         default=None,
         description="Arbitrary JSON payload for extra context",
     )
-    actor_type: str | None = Field(
-        default=None,
+    actor_type: str = Field(
+        ...,
         max_length=255,
         description="Polymorphic type of entity that triggered notification",
     )
-    actor_id: str | None = Field(
-        default=None,
+    actor_id: str = Field(
+        ...,
         max_length=255,
         description="Polymorphic ID of entity that triggered notification",
     )

--- a/src/opinionated_mixins/contrib/sqlalchemy/notification.py
+++ b/src/opinionated_mixins/contrib/sqlalchemy/notification.py
@@ -53,13 +53,13 @@ class Notification:
     )
     actor_type = Column(
         String(255),
-        nullable=True,
+        nullable=False,
         index=True,
         doc="Polymorphic type of entity that triggered notification",
     )
     actor_id = Column(
         String(255),
-        nullable=True,
+        nullable=False,
         index=True,
         doc="Polymorphic ID of entity that triggered notification",
     )

--- a/tests/mongoengine/test_notification.py
+++ b/tests/mongoengine/test_notification.py
@@ -32,8 +32,10 @@ class TestMongoEngineNotification:
 
     def test_has_actor_fields(self) -> None:
         assert hasattr(Notification, "actor_type")
+        assert Notification.actor_type.required is True
         assert Notification.actor_type.max_length == 255
         assert hasattr(Notification, "actor_id")
+        assert Notification.actor_id.required is True
         assert Notification.actor_id.max_length == 255
 
     def test_has_action_url_field(self) -> None:

--- a/tests/mongoengine/test_notification_integration.py
+++ b/tests/mongoengine/test_notification_integration.py
@@ -20,6 +20,8 @@ class TestNotificationIntegration:
         obj = MyNotification(
             notification_type="comment.reply",
             title="Someone replied",
+            actor_type="User",
+            actor_id="1",
         )
         obj.save()
         loaded = MyNotification.objects.first()
@@ -27,12 +29,16 @@ class TestNotificationIntegration:
         assert loaded.notification_type == "comment.reply"
         assert loaded.title == "Someone replied"
         assert loaded.level == NotificationLevel.INFO.value
+        assert loaded.actor_type == "User"
+        assert loaded.actor_id == "1"
 
     def test_create_with_explicit_level(self) -> None:
         obj = MyNotification(
             notification_type="order.shipped",
             title="Order shipped",
             level=NotificationLevel.SUCCESS.value,
+            actor_type="System",
+            actor_id="system",
         )
         obj.save()
         loaded = MyNotification.objects.first()
@@ -42,13 +48,13 @@ class TestNotificationIntegration:
         obj = MyNotification(
             notification_type="system.alert",
             title="Alert",
+            actor_type="System",
+            actor_id="system",
         )
         obj.save()
         loaded = MyNotification.objects.first()
         assert loaded is not None
         assert loaded.description is None
-        assert loaded.actor_type is None
-        assert loaded.actor_id is None
         assert loaded.action_url is None
         assert loaded.group_key is None
         assert loaded.seen_at is None

--- a/tests/odmantic/test_notification_integration.py
+++ b/tests/odmantic/test_notification_integration.py
@@ -27,6 +27,8 @@ class TestNotificationIntegration:
         obj = MyNotification(
             notification_type="comment.reply",
             title="Someone replied",
+            actor_type="User",
+            actor_id="1",
         )
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(MyNotification)
@@ -40,6 +42,8 @@ class TestNotificationIntegration:
             notification_type="order.shipped",
             title="Order shipped",
             level=NotificationLevel.SUCCESS,
+            actor_type="System",
+            actor_id="system",
         )
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(MyNotification)
@@ -49,13 +53,13 @@ class TestNotificationIntegration:
         obj = MyNotification(
             notification_type="system.alert",
             title="Alert",
+            actor_type="System",
+            actor_id="system",
         )
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(MyNotification)
         assert loaded is not None
         assert loaded.description is None
-        assert loaded.actor_type is None
-        assert loaded.actor_id is None
         assert loaded.seen_at is None
         assert loaded.read_at is None
         assert loaded.archived_at is None

--- a/tests/sqlalchemy/test_notification.py
+++ b/tests/sqlalchemy/test_notification.py
@@ -23,6 +23,8 @@ class TestSQLAlchemyNotification:
             obj = MyNotification(
                 notification_type="comment.reply",
                 title="Someone replied",
+                actor_type="User",
+                actor_id="1",
             )
             session.add(obj)
             session.commit()
@@ -30,6 +32,8 @@ class TestSQLAlchemyNotification:
             assert obj.notification_type == "comment.reply"
             assert obj.title == "Someone replied"
             assert obj.level == NotificationLevel.INFO
+            assert obj.actor_type == "User"
+            assert obj.actor_id == "1"
 
     def test_create_with_all_fields(self) -> None:
         now = datetime.datetime.now(datetime.timezone.utc)
@@ -61,6 +65,8 @@ class TestSQLAlchemyNotification:
             obj = MyNotification(
                 notification_type="system.alert",
                 title="Alert",
+                actor_type="System",
+                actor_id="system",
             )
             session.add(obj)
             session.commit()
@@ -72,14 +78,14 @@ class TestSQLAlchemyNotification:
             obj = MyNotification(
                 notification_type="comment.reply",
                 title="Reply",
+                actor_type="User",
+                actor_id="1",
             )
             session.add(obj)
             session.commit()
             session.refresh(obj)
             assert obj.description is None
             assert obj.data is None
-            assert obj.actor_type is None
-            assert obj.actor_id is None
             assert obj.action_url is None
             assert obj.group_key is None
             assert obj.seen_at is None


### PR DESCRIPTION
## Summary

- Make `actor_type` and `actor_id` required (non-nullable) across all 3 contrib implementations (SQLAlchemy, MongoEngine, ODMantic)
- Aligns NotificationMixin with ActivityMixin (#42), which already requires actor fields
- Updates all unit and integration tests to provide actor fields and removes None-default assertions

## Breaking Change

`actor_type` and `actor_id` are now required. Existing rows with `NULL` values need a migration backfill (e.g. `actor_type="System"`, `actor_id="system"`).

## References

4/5 real-world references make actor required: django-notifications, django-activity-stream, Stream.io, ActivityMixin (#42).

Closes #44

## Test plan

- [x] SQLAlchemy unit tests pass (6/6)
- [x] MongoEngine unit tests pass (10/10)
- [x] ODMantic unit tests pass (2/2)
- [x] Ruff lint clean

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR makes the `actor_type` and `actor_id` fields required (non-nullable) across all three NotificationMixin implementations (SQLAlchemy, MongoEngine, and ODMantic) to align with the existing ActivityMixin pattern. This is a **breaking change** that requires existing databases to migrate any NULL values to appropriate defaults before upgrading. All tests have been updated to provide actor fields when creating notification instances, and assertions checking for None defaults have been removed.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/opinionated_mixins/contrib/sqlalchemy/notification.py` |
| 2 | `src/opinionated_mixins/contrib/mongoengine/notification.py` |
| 3 | `src/opinionated_mixins/contrib/odmantic/notification.py` |
| 4 | `tests/sqlalchemy/test_notification.py` |
| 5 | `tests/mongoengine/test_notification.py` |
| 6 | `tests/mongoengine/test_notification_integration.py` |
| 7 | `tests/odmantic/test_notification_integration.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->