### PR TITLE
fix(tests): stop odmantic mixin xfails from breaking CI under pydantic 2.13

### DIFF
--- a/tests/odmantic/conftest.py
+++ b/tests/odmantic/conftest.py
@@ -1,8 +1,10 @@
 """Shared fixtures for ODMantic integration tests."""
 
+from collections.abc import Callable
+
 import pytest
 from mongomock_motor import AsyncMongoMockClient
-from odmantic import AIOEngine
+from odmantic import AIOEngine, Field, Model
 
 
 @pytest.fixture
@@ -10,3 +12,29 @@ async def mock_engine() -> AIOEngine:
     """AIOEngine backed by mongomock-motor."""
     client = AsyncMongoMockClient()
     return AIOEngine(client=client, database="testdb")
+
+
+@pytest.fixture
+def build_mixin_model() -> Callable[[type, str], type[Model]]:
+    """Return a factory that composes an ODMantic ``Model`` with a mixin.
+
+    Composing a ``Model`` with a mixin parent currently fails (issue #39:
+    ODMantic's metaclass does not process annotations inherited from mixin
+    parents). Under pydantic >= 2.13 that failure surfaces at *class-creation*
+    time as ``TypeError`` rather than at instantiation.
+
+    The model must therefore be built *inside the test body* — by calling the
+    returned factory — so the exception is raised during the test's call phase,
+    where the strict ``xfail`` marker can catch it. Building the class at import
+    time (module level) would instead raise during collection and break the
+    whole test run.
+    """
+
+    def _build(mixin: type, collection: str) -> type[Model]:
+        class MyModel(mixin, Model):
+            model_config = {"collection": collection}
+            name: str = Field(...)
+
+        return MyModel
+
+    return _build

--- a/tests/odmantic/test_created_at_integration.py
+++ b/tests/odmantic/test_created_at_integration.py
@@ -1,9 +1,14 @@
-"""Integration tests for ODMantic CreatedAt mixin."""
+"""Integration tests for ODMantic CreatedAt mixin.
+
+The model is built inside each test via the ``build_mixin_model`` fixture — not
+at module level — because composing an ODMantic ``Model`` with a mixin parent
+raises at class-creation time under pydantic >= 2.13 (see the fixture's
+docstring and issue #39). Building at import time would break collection.
+"""
 
 import datetime
 
 import pytest
-from odmantic import Field, Model
 from opinionated_mixins.contrib.odmantic import CreatedAt
 from pydantic import ValidationError
 
@@ -15,28 +20,11 @@ pytestmark = pytest.mark.xfail(
 )
 
 
-def _build_model() -> type[Model]:
-    """Build the test model composing the mixin with an ODMantic ``Model``.
-
-    This composition currently fails (see the module-level xfail). Under
-    pydantic >= 2.13 the failure surfaces at *class-creation* time as a
-    ``TypeError`` rather than at instantiation, so the model is built inside
-    each test — where the xfail marker can catch it — instead of at import
-    time, which would otherwise break test collection.
-    """
-
-    class MyModel(CreatedAt, Model):
-        model_config = {"collection": "test_created_at"}
-        name: str = Field(...)
-
-    return MyModel
-
-
 class TestCreatedAtIntegration:
     """Test CreatedAt mixin composition, instantiation, and roundtrip."""
 
-    async def test_created_at_set_on_save(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_created_at_set_on_save(self, mock_engine, build_mixin_model) -> None:
+        model_cls = build_mixin_model(CreatedAt, "test_created_at")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(model_cls)
@@ -44,8 +32,8 @@ class TestCreatedAtIntegration:
         assert loaded.created_at is not None
         assert isinstance(loaded.created_at, datetime.datetime)
 
-    async def test_created_at_is_recent(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_created_at_is_recent(self, mock_engine, build_mixin_model) -> None:
+        model_cls = build_mixin_model(CreatedAt, "test_created_at")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(model_cls)
@@ -54,8 +42,12 @@ class TestCreatedAtIntegration:
         delta = (now - loaded.created_at.replace(tzinfo=utc)).total_seconds()
         assert delta < 5
 
-    async def test_created_at_survives_roundtrip(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_created_at_survives_roundtrip(
+        self,
+        mock_engine,
+        build_mixin_model,
+    ) -> None:
+        model_cls = build_mixin_model(CreatedAt, "test_created_at")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(model_cls)

--- a/tests/odmantic/test_created_at_integration.py
+++ b/tests/odmantic/test_created_at_integration.py
@@ -8,44 +8,57 @@ from opinionated_mixins.contrib.odmantic import CreatedAt
 from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
-    raises=(ValidationError, NotImplementedError),
+    raises=(TypeError, ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 
 
-class MyModel(CreatedAt, Model):
-    """Test model composing CreatedAt with Model."""
+def _build_model() -> type[Model]:
+    """Build the test model composing the mixin with an ODMantic ``Model``.
 
-    model_config = {"collection": "test_created_at"}
-    name: str = Field(...)
+    This composition currently fails (see the module-level xfail). Under
+    pydantic >= 2.13 the failure surfaces at *class-creation* time as a
+    ``TypeError`` rather than at instantiation, so the model is built inside
+    each test — where the xfail marker can catch it — instead of at import
+    time, which would otherwise break test collection.
+    """
+
+    class MyModel(CreatedAt, Model):
+        model_config = {"collection": "test_created_at"}
+        name: str = Field(...)
+
+    return MyModel
 
 
 class TestCreatedAtIntegration:
     """Test CreatedAt mixin composition, instantiation, and roundtrip."""
 
     async def test_created_at_set_on_save(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         assert loaded is not None
         assert loaded.created_at is not None
         assert isinstance(loaded.created_at, datetime.datetime)
 
     async def test_created_at_is_recent(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         now = datetime.datetime.now(datetime.timezone.utc)
         utc = datetime.timezone.utc
         delta = (now - loaded.created_at.replace(tzinfo=utc)).total_seconds()
         assert delta < 5
 
     async def test_created_at_survives_roundtrip(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         # mongomock may truncate microseconds; compare up to millisecond precision
         diff = loaded.created_at - obj.created_at.replace(tzinfo=None)
         assert abs(diff.total_seconds()) < 0.01

--- a/tests/odmantic/test_is_active_integration.py
+++ b/tests/odmantic/test_is_active_integration.py
@@ -6,40 +6,53 @@ from opinionated_mixins.contrib.odmantic import IsActive
 from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
-    raises=(ValidationError, NotImplementedError),
+    raises=(TypeError, ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 
 
-class MyModel(IsActive, Model):
-    """Test model composing IsActive with Model."""
+def _build_model() -> type[Model]:
+    """Build the test model composing the mixin with an ODMantic ``Model``.
 
-    model_config = {"collection": "test_is_active"}
-    name: str = Field(...)
+    This composition currently fails (see the module-level xfail). Under
+    pydantic >= 2.13 the failure surfaces at *class-creation* time as a
+    ``TypeError`` rather than at instantiation, so the model is built inside
+    each test — where the xfail marker can catch it — instead of at import
+    time, which would otherwise break test collection.
+    """
+
+    class MyModel(IsActive, Model):
+        model_config = {"collection": "test_is_active"}
+        name: str = Field(...)
+
+    return MyModel
 
 
 class TestIsActiveIntegration:
     """Test IsActive mixin composition, instantiation, and roundtrip."""
 
     async def test_defaults_true(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         assert loaded is not None
         assert loaded.is_active is True
 
     async def test_set_to_false(self, mock_engine) -> None:
-        obj = MyModel(name="test", is_active=False)
+        model_cls = _build_model()
+        obj = model_cls(name="test", is_active=False)
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         assert loaded.is_active is False
 
     async def test_update_persists(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
         obj.is_active = False
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         assert loaded.is_active is False

--- a/tests/odmantic/test_is_active_integration.py
+++ b/tests/odmantic/test_is_active_integration.py
@@ -1,7 +1,12 @@
-"""Integration tests for ODMantic IsActive mixin."""
+"""Integration tests for ODMantic IsActive mixin.
+
+The model is built inside each test via the ``build_mixin_model`` fixture — not
+at module level — because composing an ODMantic ``Model`` with a mixin parent
+raises at class-creation time under pydantic >= 2.13 (see the fixture's
+docstring and issue #39). Building at import time would break collection.
+"""
 
 import pytest
-from odmantic import Field, Model
 from opinionated_mixins.contrib.odmantic import IsActive
 from pydantic import ValidationError
 
@@ -13,43 +18,26 @@ pytestmark = pytest.mark.xfail(
 )
 
 
-def _build_model() -> type[Model]:
-    """Build the test model composing the mixin with an ODMantic ``Model``.
-
-    This composition currently fails (see the module-level xfail). Under
-    pydantic >= 2.13 the failure surfaces at *class-creation* time as a
-    ``TypeError`` rather than at instantiation, so the model is built inside
-    each test — where the xfail marker can catch it — instead of at import
-    time, which would otherwise break test collection.
-    """
-
-    class MyModel(IsActive, Model):
-        model_config = {"collection": "test_is_active"}
-        name: str = Field(...)
-
-    return MyModel
-
-
 class TestIsActiveIntegration:
     """Test IsActive mixin composition, instantiation, and roundtrip."""
 
-    async def test_defaults_true(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_defaults_true(self, mock_engine, build_mixin_model) -> None:
+        model_cls = build_mixin_model(IsActive, "test_is_active")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(model_cls)
         assert loaded is not None
         assert loaded.is_active is True
 
-    async def test_set_to_false(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_set_to_false(self, mock_engine, build_mixin_model) -> None:
+        model_cls = build_mixin_model(IsActive, "test_is_active")
         obj = model_cls(name="test", is_active=False)
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(model_cls)
         assert loaded.is_active is False
 
-    async def test_update_persists(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_update_persists(self, mock_engine, build_mixin_model) -> None:
+        model_cls = build_mixin_model(IsActive, "test_is_active")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         obj.is_active = False

--- a/tests/odmantic/test_updated_at_integration.py
+++ b/tests/odmantic/test_updated_at_integration.py
@@ -8,56 +8,70 @@ from opinionated_mixins.contrib.odmantic import UpdatedAt
 from pydantic import ValidationError
 
 pytestmark = pytest.mark.xfail(
-    raises=(ValidationError, NotImplementedError),
+    raises=(TypeError, ValidationError, NotImplementedError),
     reason="ODMantic metaclass does not process annotations from mixin parents. "
     "See: https://github.com/hasansezertasan/opinionated-mixins/issues/39",
     strict=True,
 )
 
 
-class MyModel(UpdatedAt, Model):
-    """Test model composing UpdatedAt with Model."""
+def _build_model() -> type[Model]:
+    """Build the test model composing the mixin with an ODMantic ``Model``.
 
-    model_config = {"collection": "test_updated_at"}
-    name: str = Field(...)
+    This composition currently fails (see the module-level xfail). Under
+    pydantic >= 2.13 the failure surfaces at *class-creation* time as a
+    ``TypeError`` rather than at instantiation, so the model is built inside
+    each test — where the xfail marker can catch it — instead of at import
+    time, which would otherwise break test collection.
+    """
+
+    class MyModel(UpdatedAt, Model):
+        model_config = {"collection": "test_updated_at"}
+        name: str = Field(...)
+
+    return MyModel
 
 
 class TestUpdatedAtIntegration:
     """Test UpdatedAt mixin composition, instantiation, and roundtrip."""
 
     async def test_updated_at_set_on_save(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         assert loaded is not None
         assert loaded.updated_at is not None
         assert isinstance(loaded.updated_at, datetime.datetime)
 
     async def test_updated_at_is_recent(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         now = datetime.datetime.now(datetime.timezone.utc)
         utc = datetime.timezone.utc
         delta = (now - loaded.updated_at.replace(tzinfo=utc)).total_seconds()
         assert delta < 5
 
     async def test_updated_at_survives_roundtrip(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         # mongomock may truncate microseconds; compare up to millisecond precision
         diff = loaded.updated_at - obj.updated_at.replace(tzinfo=None)
         assert abs(diff.total_seconds()) < 0.01
 
     async def test_updated_at_can_be_manually_refreshed(self, mock_engine) -> None:
-        obj = MyModel(name="test")
+        model_cls = _build_model()
+        obj = model_cls(name="test")
         await mock_engine.save(obj)
         first_updated = obj.updated_at
         # Mixin provides the field; consumer is responsible for updating it
         obj.updated_at = datetime.datetime.now(datetime.timezone.utc)
         obj.name = "changed"
         await mock_engine.save(obj)
-        loaded = await mock_engine.find_one(MyModel)
+        loaded = await mock_engine.find_one(model_cls)
         assert loaded.name == "changed"
         assert loaded.updated_at >= first_updated

--- a/tests/odmantic/test_updated_at_integration.py
+++ b/tests/odmantic/test_updated_at_integration.py
@@ -1,9 +1,14 @@
-"""Integration tests for ODMantic UpdatedAt mixin."""
+"""Integration tests for ODMantic UpdatedAt mixin.
+
+The model is built inside each test via the ``build_mixin_model`` fixture — not
+at module level — because composing an ODMantic ``Model`` with a mixin parent
+raises at class-creation time under pydantic >= 2.13 (see the fixture's
+docstring and issue #39). Building at import time would break collection.
+"""
 
 import datetime
 
 import pytest
-from odmantic import Field, Model
 from opinionated_mixins.contrib.odmantic import UpdatedAt
 from pydantic import ValidationError
 
@@ -15,28 +20,11 @@ pytestmark = pytest.mark.xfail(
 )
 
 
-def _build_model() -> type[Model]:
-    """Build the test model composing the mixin with an ODMantic ``Model``.
-
-    This composition currently fails (see the module-level xfail). Under
-    pydantic >= 2.13 the failure surfaces at *class-creation* time as a
-    ``TypeError`` rather than at instantiation, so the model is built inside
-    each test — where the xfail marker can catch it — instead of at import
-    time, which would otherwise break test collection.
-    """
-
-    class MyModel(UpdatedAt, Model):
-        model_config = {"collection": "test_updated_at"}
-        name: str = Field(...)
-
-    return MyModel
-
-
 class TestUpdatedAtIntegration:
     """Test UpdatedAt mixin composition, instantiation, and roundtrip."""
 
-    async def test_updated_at_set_on_save(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_updated_at_set_on_save(self, mock_engine, build_mixin_model) -> None:
+        model_cls = build_mixin_model(UpdatedAt, "test_updated_at")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(model_cls)
@@ -44,8 +32,8 @@ class TestUpdatedAtIntegration:
         assert loaded.updated_at is not None
         assert isinstance(loaded.updated_at, datetime.datetime)
 
-    async def test_updated_at_is_recent(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_updated_at_is_recent(self, mock_engine, build_mixin_model) -> None:
+        model_cls = build_mixin_model(UpdatedAt, "test_updated_at")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(model_cls)
@@ -54,8 +42,12 @@ class TestUpdatedAtIntegration:
         delta = (now - loaded.updated_at.replace(tzinfo=utc)).total_seconds()
         assert delta < 5
 
-    async def test_updated_at_survives_roundtrip(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_updated_at_survives_roundtrip(
+        self,
+        mock_engine,
+        build_mixin_model,
+    ) -> None:
+        model_cls = build_mixin_model(UpdatedAt, "test_updated_at")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         loaded = await mock_engine.find_one(model_cls)
@@ -63,8 +55,12 @@ class TestUpdatedAtIntegration:
         diff = loaded.updated_at - obj.updated_at.replace(tzinfo=None)
         assert abs(diff.total_seconds()) < 0.01
 
-    async def test_updated_at_can_be_manually_refreshed(self, mock_engine) -> None:
-        model_cls = _build_model()
+    async def test_updated_at_can_be_manually_refreshed(
+        self,
+        mock_engine,
+        build_mixin_model,
+    ) -> None:
+        model_cls = build_mixin_model(UpdatedAt, "test_updated_at")
         obj = model_cls(name="test")
         await mock_engine.save(obj)
         first_updated = obj.updated_at


### PR DESCRIPTION
## Problem

CI is red on `main` (both Python 3.10 and 3.14). The `odmantic` integration tests for the mixins whose fields **all have defaults** — `CreatedAt`, `UpdatedAt`, `IsActive` — error during **collection**:

```
TypeError: field name is defined without type annotation
  odmantic/model.py:235 in __validate_cls_namespace__
```

## Root cause

This is the known, documented limitation from #39 — ODMantic's metaclass doesn't process annotations inherited from mixin parents. The tests already mark it `xfail(strict=True, raises=(ValidationError, NotImplementedError))`.

What changed: under **pydantic ≥ 2.13**, pydantic's `ModelMetaclass` now surfaces inherited default-bearing fields in the subclass namespace, so ODMantic's validation trips at **class-creation time** with a `TypeError` — at module import — *before* pytest can apply the xfail. That turns a handled xfail into an uncatchable collection error.

Only the three mixins whose fields all have defaults are affected (a required `Field(...)` doesn't become a class attribute, so those tests still xfail at runtime as before).

`odmantic==1.1.0` is the latest release and pins only `pydantic>=2.5.2` (no upper bound), so this can't be fixed by a version bump.

## Fix

Build the test model **inside each test** (via a small `_build_model()` factory) so the failure occurs in the test-call phase, where the strict xfail catches it, and add `TypeError` to the accepted `raises`. Collection no longer imports a failing class.

The xfail stays **strict**, so if #39 is ever resolved these tests will XPASS and flag that the marker should be removed — no signal lost.

## Verification

- `uv run pytest tests` → **242 passed, 36 xfailed**, 0 errors
- `ruff check .`, `ruff format --check .`, `mypy src/opinionated_mixins` → all clean

Refs #39

## Summary by Sourcery

Adjust ODMantic mixin integration tests to avoid collection-time failures under newer pydantic versions while preserving strict xfail behavior.

Tests:
- Instantiate ODMantic models inside each xfailed test via a factory to ensure failures occur during test execution instead of import-time class creation.
- Expand the xfail `raises` set for ODMantic mixin tests to include `TypeError` alongside existing expected exceptions.